### PR TITLE
Add missing header to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 CPPFLAGS=-Ivendor/gtest-1.6.0/include
-include_HEADERS = include/restclient.h
+include_HEADERS = include/restclient.h include/meta.h
 check_PROGRAMS = test-program
 test_program_SOURCES = test/test_restclient_delete.cpp test/test_restclient_get.cpp test/test_restclient_post.cpp test/test_restclient_put.cpp test/tests.cpp
 test_program_LDADD = .libs/librestclient-cpp.a


### PR DESCRIPTION
This header was not being installed. Resolved by this patch.
