### PR TITLE
move two include instructions to source file to avoid macro pollution

### DIFF
--- a/include/restclient-cpp/restclient.h
+++ b/include/restclient-cpp/restclient.h
@@ -9,11 +9,9 @@
 #ifndef INCLUDE_RESTCLIENT_H_
 #define INCLUDE_RESTCLIENT_H_
 
-#include <curl/curl.h>
 #include <string>
 #include <map>
 #include <cstdlib>
-#include "meta.h"
 #include <algorithm>
 
 class RestClient

--- a/source/restclient.cpp
+++ b/source/restclient.cpp
@@ -8,7 +8,9 @@
          INCLUDES
   ========================*/
 #include "restclient-cpp/restclient.h"
+#include "restclient-cpp/meta.h"
 
+#include <curl/curl.h>
 #include <cstring>
 #include <string>
 #include <iostream>

--- a/test/test_restclient_delete.cpp
+++ b/test/test_restclient_delete.cpp
@@ -19,7 +19,7 @@ class RestClientDeleteTest : public ::testing::Test
 
     virtual void SetUp()
     {
-      url = "http://http-test-server.heroku.com";
+      url = "http://http-test-server.herokuapp.com";
       ctype = "";
       data = "";
     }

--- a/test/test_restclient_get.cpp
+++ b/test/test_restclient_get.cpp
@@ -19,7 +19,7 @@ class RestClientGetTest : public ::testing::Test
 
     virtual void SetUp()
     {
-      url = "http://http-test-server.heroku.com";
+      url = "http://http-test-server.herokuapp.com";
       ctype = "";
       data = "";
     }

--- a/test/test_restclient_post.cpp
+++ b/test/test_restclient_post.cpp
@@ -19,7 +19,7 @@ class RestClientPostTest : public ::testing::Test
 
     virtual void SetUp()
     {
-      url = "http://http-test-server.heroku.com";
+      url = "http://http-test-server.herokuapp.com";
       ctype = "Content-Type: text/text";
       data = "data";
     }

--- a/test/test_restclient_put.cpp
+++ b/test/test_restclient_put.cpp
@@ -19,7 +19,7 @@ class RestClientPutTest : public ::testing::Test
 
     virtual void SetUp()
     {
-      url = "http://http-test-server.heroku.com";
+      url = "http://http-test-server.herokuapp.com";
       ctype = "Content-Type: text/text";
       data = "data";
     }


### PR DESCRIPTION
When one use this lib, he should include the header "restclient.h". If there are some macros which are meaningless for him, it will bother him. For example, he can not define his own VERSION since it already exists in "meta.h"(which is included by restclient.h before). And it will be diffrent to move it to source file(cpp file). 
The reason to move "#include <curl/curl.h>" to source file is similar, there is no namespace in curl/curl.h and it‘s unnecessary for it to appear in restclient.h