### PR TITLE
Issue #21 - Memory leak

### DIFF
--- a/source/restclient.cpp
+++ b/source/restclient.cpp
@@ -70,15 +70,14 @@ RestClient::response RestClient::get(const std::string& url)
     {
       ret.body = "Failed to query.";
       ret.code = -1;
-      return ret;
-    }
-    long http_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    ret.code = static_cast<int>(http_code);
-
-    curl_easy_cleanup(curl);
-    curl_global_cleanup();
+    } else {
+	  long http_code = 0;
+	  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+	  ret.code = static_cast<int>(http_code);
+	}
   }
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
 
   return ret;
 }
@@ -135,20 +134,20 @@ RestClient::response RestClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
     /** perform the actual query */
     res = curl_easy_perform(curl);
+	
     if (res != CURLE_OK)
     {
       ret.body = "Failed to query.";
       ret.code = -1;
-      return ret;
-    }
-    long http_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    ret.code = static_cast<int>(http_code);
-
-    curl_slist_free_all(header);
-    curl_easy_cleanup(curl);
-    curl_global_cleanup();
+    } else {
+	  long http_code = 0;
+	  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+	  ret.code = static_cast<int>(http_code);
+	}
   }
+  curl_slist_free_all(header);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
 
   return ret;
 }
@@ -220,15 +219,16 @@ RestClient::response RestClient::put(const std::string& url,
     {
       ret.body = "Failed to query.";
       ret.code = -1;
-      return ret;
-    }
-    long http_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    ret.code = static_cast<int>(http_code);
+    } else {
+	  long http_code = 0;
+	  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+	  ret.code = static_cast<int>(http_code);
+	}
+  }
 
-    curl_slist_free_all(header);
-    curl_easy_cleanup(curl);
-    curl_global_cleanup();
+  curl_slist_free_all(header);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
   }
 
   return ret;
@@ -280,16 +280,16 @@ RestClient::response RestClient::del(const std::string& url)
     {
       ret.body = "Failed to query.";
       ret.code = -1;
-      return ret;
-    }
-    long http_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    ret.code = static_cast<int>(http_code);
-
-    curl_easy_cleanup(curl);
-    curl_global_cleanup();
+    } else {
+	  long http_code = 0;
+	  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+	  ret.code = static_cast<int>(http_code);
+	}
   }
 
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+  
   return ret;
 }
 
@@ -330,7 +330,7 @@ size_t RestClient::header_callback(void *data, size_t size, size_t nmemb,
   std::string header(reinterpret_cast<char*>(data), size*nmemb);
   size_t seperator = header.find_first_of(":");
   if ( std::string::npos == seperator ) {
-    //roll with non seperated headers...
+    //roll with non separated headers...
     trim(header);
     if ( 0 == header.length() ){
 	return (size * nmemb); //blank line;

--- a/source/restclient.cpp
+++ b/source/restclient.cpp
@@ -145,7 +145,6 @@ RestClient::response RestClient::post(const std::string& url,
 	  ret.code = static_cast<int>(http_code);
 	}
   }
-  curl_slist_free_all(header);
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 

--- a/source/restclient.cpp
+++ b/source/restclient.cpp
@@ -143,7 +143,8 @@ RestClient::response RestClient::post(const std::string& url,
 	  long http_code = 0;
 	  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 	  ret.code = static_cast<int>(http_code);
-	}
+    }
+    curl_slist_free_all(header);
   }
   curl_easy_cleanup(curl);
   curl_global_cleanup();
@@ -222,13 +223,13 @@ RestClient::response RestClient::put(const std::string& url,
 	  long http_code = 0;
 	  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 	  ret.code = static_cast<int>(http_code);
-	}
+    }
+    curl_slist_free_all(header);
+
   }
 
-  curl_slist_free_all(header);
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  }
 
   return ret;
 }


### PR DESCRIPTION
This is my first contribution to an open source project and my first use of GitHub so if I did anything incorrectly, just delete this entire thing.

If the remote server does not respond to the HTTP request, line 223 (for example) returns from the PUT function before doing the CURL cleanups on lines 229 thru 231. This causes a memory leak.

I tested the following code change with the PUT function and it resolves the leak. I made changes in all functions that had similar code.

if (res != CURLE_OK)
{
  ret.body = "Failed to query.";
  ret.code = -1;
  //return ret; //Commented the return
} else { //else added here
  long http_code = 0;
  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
  ret.code = static_cast(http_code);
}
...Followed by CURL cleanup and return statement.

Functions now have only one return statement.