### PR TITLE
Ensure the built shared library does not have dynamic references to l…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,6 @@ AS_IF([test "x$restclient_cpp_curl_headers_found" != "xyes"],
 # Checks for libraries.
 # FIXME: Replace `main' with a function in `-lcurl':
 AC_CHECK_LIB([curl], [main])
-# FIXME: Replace `main' with a function in `-lgtest':
-AC_CHECK_LIB([gtest], [main])
 
 # Checks for header files.
 


### PR DESCRIPTION
…ibgtest.

See https://github.com/mrtazz/restclient-cpp/issues/34
Since -lgtest is included in the test_program build flags, it is not needed to check for it building the main library.