### PR TITLE
Connection: Initialize timeout and followRedirects

### DIFF
--- a/source/connection.cc
+++ b/source/connection.cc
@@ -31,6 +31,8 @@ RestClient::Connection::Connection(const std::string baseUrl)
     throw std::runtime_error("Couldn't initialize curl handle");
   }
   this->baseUrl = baseUrl;
+  this->timeout = 0;
+  this->followRedirects = false;
 }
 
 RestClient::Connection::~Connection() {


### PR DESCRIPTION
This fixes the following Valgrind failure:

```
==6158== Conditional jump or move depends on uninitialised value(s)
==6158==    at 0x4738F2: RestClient::Connection::performCurlRequest(std::string const&) (REDACTED)
==6158==    by 0x473D10: RestClient::Connection::get(std::string const&) (REDACTED)
==6158==    by 0x472779: RestClient::get(std::string const&) (REDACTED)
==6158==    by 0x40E59F: RestClientCpp_Http_Test::TestBody() (REDACTED)
==6158==    by 0x447798: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (REDACTED)
==6158==    by 0x43A2CE: testing::Test::Run() (REDACTED)
==6158==    by 0x43A38C: testing::TestInfo::Run() (REDACTED)
==6158==    by 0x43A4A4: testing::TestCase::Run() (REDACTED)
==6158==    by 0x43A757: testing::internal::UnitTestImpl::RunAllTests() (REDACTED)
==6158==    by 0x43A9F8: testing::UnitTest::Run() (REDACTED)
==6158==    by 0x40C99F: main (REDACTED)
==6158==
{
   <insert_a_suppression_name_here>
   Memcheck:Cond
   fun:_ZN10RestClient10Connection18performCurlRequestERKSs
   fun:_ZN10RestClient10Connection3getERKSs
   fun:_ZN10RestClient3getERKSs
   fun:_ZN23RestClientCpp_Http_Test8TestBodyEv
   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
   fun:_ZN7testing4Test3RunEv
   fun:_ZN7testing8TestInfo3RunEv
   fun:_ZN7testing8TestCase3RunEv
   fun:_ZN7testing8internal12UnitTestImpl11RunAllTestsEv
   fun:_ZN7testing8UnitTest3RunEv
   fun:main
}
```