### PR TITLE
add client cert & key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ typedef struct {
     std::string username;
     std::string password;
   } basicAuth;
+
+  std::string certPath;
+  std::string certType;
+  std::string keyPath;
   std::string customUserAgent;
   struct {
     // total time of the last request in seconds Total time of previous
@@ -159,6 +163,19 @@ In order to provide an easy to use API, the simple usage via the static
 methods implicitly calls the curl global functions and is therefore also **not
 thread-safe**.
 
+## HTTPS User Certificate
+
+Simple wrapper functions are provided to allow clients to authenticate using certificates.
+Under the hood these wrappers set cURL options, e.g. `CURLOPT_SSLCERT`, using `curl_easy_setopt`.
+
+```cpp
+// set CURLOPT_SSLCERT
+conn->SetCertPath(certPath);
+// set CURLOPT_SSLCERTTYPE
+conn->SetCertType(type);
+// set CURLOPT_SSLKEY
+conn->SetKeyPath(keyPath);
+``` 
 
 ## Dependencies
 - [libcurl][]

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ thread-safe**.
 
 Simple wrapper functions are provided to allow clients to authenticate using certificates.
 Under the hood these wrappers set cURL options, e.g. `CURLOPT_SSLCERT`, using `curl_easy_setopt`.
+Note: currently `libcurl` compiled with `gnutls` (e.g. `libcurl4-gnutls-dev` on
+ubuntu) is buggy in that it returns a wrong error code when these options are set to invalid values.
 
 ```cpp
 // set CURLOPT_SSLCERT

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -99,6 +99,10 @@ class Connection {
         std::string username;
         std::string password;
       } basicAuth;
+
+      std::string certPath;
+      std::string certType;
+      std::string keyPath;
       std::string customUserAgent;
       RequestInfo lastRequest;
     } Info;
@@ -125,6 +129,15 @@ class Connection {
     // set the Certificate Authority (CA) Info which is the path to file holding
     // certificates to be used to verify peers. See CURLOPT_CAINFO
     void SetCAInfoFilePath(const std::string& caInfoFilePath);
+
+    // set CURLOPT_SSLCERT
+    void SetCertPath(const std::string& cert);
+
+    // set CURLOPT_SSLCERTTYPE
+    void SetCertType(const std::string& type);
+
+    // set CURLOPT_SSLKEY. Default format is PEM
+    void SetKeyPath(const std::string& keyPath);
 
     std::string GetUserAgent();
 
@@ -162,6 +175,9 @@ class Connection {
     std::string customUserAgent;
     std::string caInfoFilePath;
     RequestInfo lastRequest;
+    std::string certPath;
+    std::string certType;
+    std::string keyPath;
     RestClient::Response performCurlRequest(const std::string& uri);
 };
 };  // namespace RestClient

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -59,6 +59,10 @@ RestClient::Connection::GetInfo() {
   ret.customUserAgent = this->customUserAgent;
   ret.lastRequest = this->lastRequest;
 
+  ret.certPath = this->certPath;
+  ret.certType = this->certType;
+  ret.keyPath = this->keyPath;
+
   return ret;
 }
 
@@ -170,6 +174,21 @@ RestClient::Connection::SetBasicAuth(const std::string& username,
   this->basicAuth.password = password;
 }
 
+void
+RestClient::Connection::SetCertPath(const std::string& cert) {
+  this->certPath = cert;
+}
+
+void
+RestClient::Connection::SetCertType(const std::string& certType) {
+  this->certType = certType;
+}
+
+void
+RestClient::Connection::SetKeyPath(const std::string& keyPath) {
+  this->keyPath = keyPath;
+}
+
 /**
  * @brief helper function to get called from the actual request methods to
  * prepare the curlHandle for transfer with generic options, perform the
@@ -242,6 +261,24 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
     curl_easy_setopt(this->curlHandle, CURLOPT_CAINFO,
                      this->caInfoFilePath.c_str());
   }
+
+  // set cert file path
+  if (!this->certPath.empty()) {
+    curl_easy_setopt(this->curlHandle, CURLOPT_SSLCERT,
+                     this->certPath.c_str());
+  }
+
+  // set cert type 
+  if (!this->certType.empty()) {
+    curl_easy_setopt(this->curlHandle, CURLOPT_SSLCERTTYPE,
+                     this->certType.c_str());
+  }
+  // set key file path
+  if (!this->keyPath.empty()) {
+    curl_easy_setopt(this->curlHandle, CURLOPT_SSLKEY,
+                     this->keyPath.c_str());
+  }
+
   res = curl_easy_perform(this->curlHandle);
   if (res != CURLE_OK) {
     if (res == CURLE_OPERATION_TIMEDOUT) {

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -281,12 +281,18 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
 
   res = curl_easy_perform(this->curlHandle);
   if (res != CURLE_OK) {
-    if (res == CURLE_OPERATION_TIMEDOUT) {
-      ret.code = res;
-      ret.body = "Operation Timeout.";
-    } else {
-      ret.body = "Failed to query.";
-      ret.code = -1;
+    switch (res) {
+      case CURLE_OPERATION_TIMEDOUT:
+        ret.code = res;
+        ret.body = "Operation Timeout.";
+        break;
+      case CURLE_SSL_CERTPROBLEM:
+        ret.code = res;
+        ret.body = curl_easy_strerror(res);
+        break;
+      default:
+        ret.body = "Failed to query.";
+        ret.code = -1;
     }
   } else {
     int64_t http_code = 0;

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -268,7 +268,7 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
                      this->certPath.c_str());
   }
 
-  // set cert type 
+  // set cert type
   if (!this->certType.empty()) {
     curl_easy_setopt(this->curlHandle, CURLOPT_SSLCERTTYPE,
                      this->certType.c_str());

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -92,6 +92,17 @@ TEST_F(ConnectionTest, TestBasicAuth)
 
 }
 
+TEST_F(ConnectionTest, TestSSLCert)
+{
+  conn->SetCertPath("non-existent file");
+  conn->SetKeyPath("invalid cert type");
+  conn->SetCertType("invalid cert type");
+  RestClient::Response res = conn->get("/get");
+
+  EXPECT_EQ("Failed to query.", res.body);
+  EXPECT_EQ(-1, res.code);
+}
+
 TEST_F(ConnectionTest, TestSetHeaders)
 {
   RestClient::HeaderFields headers;

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -95,12 +95,11 @@ TEST_F(ConnectionTest, TestBasicAuth)
 TEST_F(ConnectionTest, TestSSLCert)
 {
   conn->SetCertPath("non-existent file");
-  conn->SetKeyPath("invalid cert type");
+  conn->SetKeyPath("non-existent key path");
   conn->SetCertType("invalid cert type");
   RestClient::Response res = conn->get("/get");
 
-  EXPECT_EQ("Failed to query.", res.body);
-  EXPECT_EQ(-1, res.code);
+  EXPECT_EQ(58, res.code);
 }
 
 TEST_F(ConnectionTest, TestSetHeaders)


### PR DESCRIPTION
Allow users to specify client certs & keys by setting `CURLOPT_SSLCERT`, `CURLOPT_SSLCERTTYPE`, `CURLOPT_SSLKEY`.
