### PR TITLE
Fix -Wpedantic warning

### DIFF
--- a/include/restclient-cpp/restclient.h
+++ b/include/restclient-cpp/restclient.h
@@ -59,6 +59,6 @@ Response put(const std::string& url,
               const std::string& data);
 Response del(const std::string& url);
 
-};  // namespace RestClient
+}  // namespace RestClient
 
 #endif  // INCLUDE_RESTCLIENT_CPP_RESTCLIENT_H_


### PR DESCRIPTION
This fixes the following warning when compiling with `-Wpedantic`

```
/usr/local/include/restclient-cpp/restclient.h:62:2: warning: extra ‘;’ [-Wpedantic]
 };  // namespace RestClient
```