### PR TITLE
File streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ usr
 # generated files
 docs
 include/restclient-cpp/version.h
+vendor/gtest-1.7.0

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS=-I m4
-CPPFLAGS=-Iinclude
+CPPFLAGS=-Iinclude -std=c++11
 check_PROGRAMS = test-program
 pkginclude_HEADERS = include/restclient-cpp/restclient.h include/restclient-cpp/version.h include/restclient-cpp/connection.h include/restclient-cpp/helpers.h
 BUILT_SOURCES = include/restclient-cpp/version.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS=-I m4
-CPPFLAGS=-Iinclude -std=c++11
+CPPFLAGS=-Iinclude -std=c++0x
 check_PROGRAMS = test-program
 pkginclude_HEADERS = include/restclient-cpp/restclient.h include/restclient-cpp/version.h include/restclient-cpp/connection.h include/restclient-cpp/helpers.h
 BUILT_SOURCES = include/restclient-cpp/version.h

--- a/README.md
+++ b/README.md
@@ -140,11 +140,38 @@ typedef struct {
 } Info;
 ```
 
+#### Transferring Large Data
+By default the client keeps the request and response body in memory. Alternatively 
+you can instruct it to read the data to be sent from a file or to write the response 
+body to a file instead of a memory buffer. This is useful for downloading or uploading 
+files.
+A progress indicator can be installed to track the amounts of data being transferred.
+
+```cpp
+// to upload data from a file, use:
+conn->InputFromFile("/path/to/input/file");
+
+// to download data to a file, use:
+conn->OutputToFile("/path/to/output/file");
+
+// to track upload / download progress, you can install a std::function to be called, e.g.:
+conn->SetProgressCallback([](long long totalDownloadBytes, long long downloadedBytes, long long totalUploadBytes, long long uploadedBytes) {
+    std::cout << "Fetched bytes: " << downloadedBytes << std::endl;
+});
+
+```
+
 #### Persistent connections/Keep-Alive
 The connection object stores the curl easy handle in an instance variable and
 uses that for the lifetime of the object. This means curl will [automatically
 reuse connections][curl_keepalive] made with that handle.
 
+#### Debugging
+A proxy can be configured for debugging.
+
+```cpp
+conn->UseDebugProxy("localhost:8080");
+```
 
 ## Thread Safety
 restclient-cpp leans heavily on libcurl as it aims to provide a thin wrapper

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -22,7 +22,10 @@
  */
 namespace RestClient {
 
-/**
+// progress callback function type
+typedef std::function<void(long long totalDownloadBytes, long long  downloadedBytes, long long totalUploadBytes, long long uploadedBytes)> ProgressCallback;
+
+    /**
   * @brief Connection object for advanced usage
   */
 class Connection {
@@ -141,6 +144,15 @@ class Connection {
                       const std::string& value);
 
 
+    // stream response body to file instead of using memory
+    void OutputToFile(const std::string& outputFileName);
+    // stream request body from file instead of using memory (tested only with POST)
+    void InputFromFile(const std::string& inputFileName);
+    // use a proxy and do not check SSL certificate; for debugging only!
+    void UseDebugProxy(const std::string &proxyUrl);
+    // install a progress callback
+    void SetProgressCallback(RestClient::ProgressCallback && callback);
+
     // Basic HTTP verb methods
     RestClient::Response get(const std::string& uri);
     RestClient::Response post(const std::string& uri,
@@ -163,6 +175,11 @@ class Connection {
     std::string caInfoFilePath;
     RequestInfo lastRequest;
     RestClient::Response performCurlRequest(const std::string& uri);
+    std::string outputFileName;
+    std::string inputFileName;
+    FILE *outFile;
+    FILE *inFile;
+    RestClient::ProgressCallback progressCallback;
 };
 };  // namespace RestClient
 

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -23,7 +23,8 @@
 namespace RestClient {
 
 // progress callback function type
-typedef std::function<void(long long totalDownloadBytes, long long  downloadedBytes, long long totalUploadBytes, long long uploadedBytes)> ProgressCallback;
+typedef std::function<void(int64_t totalDownloadBytes, int64_t downloadedBytes,
+        int64_t totalUploadBytes, int64_t uploadedBytes)> ProgressCallback;
 
     /**
   * @brief Connection object for advanced usage
@@ -146,7 +147,7 @@ class Connection {
 
     // stream response body to file instead of using memory
     void OutputToFile(const std::string& outputFileName);
-    // stream request body from file instead of using memory (tested only with POST)
+    // stream request body from file instead of using memory
     void InputFromFile(const std::string& inputFileName);
     // use a proxy and do not check SSL certificate; for debugging only!
     void UseDebugProxy(const std::string &proxyUrl);

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <map>
 #include <cstdlib>
+#include <functional>
 
 #include "restclient-cpp/restclient.h"
 #include "restclient-cpp/version.h"

--- a/include/restclient-cpp/helpers.h
+++ b/include/restclient-cpp/helpers.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <algorithm>
 #include <functional>
+#include <curl/curlbuild.h>
 
 #include "restclient-cpp/version.h"
 
@@ -48,6 +49,8 @@ namespace Helpers {
   // read callback function
   size_t read_callback(void *ptr, size_t size, size_t nmemb,
                               void *userdata);
+  // progress callback
+  int progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
 
   // trim from start
   static inline std::string &ltrim(std::string &s) {  // NOLINT

--- a/include/restclient-cpp/helpers.h
+++ b/include/restclient-cpp/helpers.h
@@ -9,10 +9,10 @@
 #ifndef INCLUDE_RESTCLIENT_CPP_HELPERS_H_
 #define INCLUDE_RESTCLIENT_CPP_HELPERS_H_
 
+#include <curl/curlbuild.h>
 #include <string>
 #include <algorithm>
 #include <functional>
-#include <curl/curlbuild.h>
 
 #include "restclient-cpp/version.h"
 
@@ -50,7 +50,8 @@ namespace Helpers {
   size_t read_callback(void *ptr, size_t size, size_t nmemb,
                               void *userdata);
   // progress callback
-  int progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
+  int progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
+          curl_off_t ultotal, curl_off_t ulnow);
 
   // trim from start
   static inline std::string &ltrim(std::string &s) {  // NOLINT

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -262,7 +262,7 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
   if (this->timeout) {
     curl_easy_setopt(this->curlHandle, CURLOPT_TIMEOUT, this->timeout);
     // dont want to get a sig alarm on timeout
-    curl_easy_setopt(this->curlHandle, CURLOPT_NOSIGNAL, 0); // 0 is required for MacOS
+    curl_easy_setopt(this->curlHandle, CURLOPT_NOSIGNAL, 1);
   }
   // set follow redirect
   if (this->followRedirects == true) {

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -262,7 +262,7 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
   if (this->timeout) {
     curl_easy_setopt(this->curlHandle, CURLOPT_TIMEOUT, this->timeout);
     // dont want to get a sig alarm on timeout
-    curl_easy_setopt(this->curlHandle, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(this->curlHandle, CURLOPT_NOSIGNAL, 0); // 0 is required for MacOS
   }
   // set follow redirect
   if (this->followRedirects == true) {
@@ -275,7 +275,8 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
   }
   res = curl_easy_perform(this->curlHandle);
   if (res != CURLE_OK) {
-    ret.code = - res; // use negative curl error code as response code
+    // use negative curl error code as response code
+    ret.code = - res;
     if (res == CURLE_OPERATION_TIMEDOUT) {
       ret.body = "Operation Timeout.";
     } else {
@@ -440,9 +441,11 @@ void RestClient::Connection::UseDebugProxy(const std::string &proxyUrl) {
  *
  * @param callback the callback function
  */
-void RestClient::Connection::SetProgressCallback(RestClient::ProgressCallback && callback) {
+void RestClient::Connection::SetProgressCallback(
+        RestClient::ProgressCallback && callback) {
   progressCallback = std::move(callback);
-  curl_easy_setopt(this->curlHandle, CURLOPT_XFERINFOFUNCTION, RestClient::Helpers::progress_callback);
+  curl_easy_setopt(this->curlHandle, CURLOPT_XFERINFOFUNCTION,
+          RestClient::Helpers::progress_callback);
   curl_easy_setopt(this->curlHandle, CURLOPT_XFERINFODATA, &progressCallback);
   curl_easy_setopt(this->curlHandle, CURLOPT_NOPROGRESS, 0L);
 }

--- a/source/helpers.cc
+++ b/source/helpers.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include "restclient-cpp/restclient.h"
+#include "restclient-cpp/connection.h"
 
 /**
  * @brief write callback function for libcurl
@@ -87,4 +88,20 @@ size_t RestClient::Helpers::read_callback(void *data, size_t size,
   u->data += copy_size;
   /** return copied size */
   return copy_size;
+}
+
+
+/**
+ * @brief Progress callback for libcurl.
+ *
+ * @param clientp user data
+ * @param dltotal total download size in bytes
+ * @param dlnow already downloaded bytes
+ * @param ultotal total upload size in bytes
+ * @param ulnow already downloaded bytes
+ */
+int RestClient::Helpers::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
+  RestClient::ProgressCallback *callBackPtr = (RestClient::ProgressCallback *)clientp;
+  (*callBackPtr)(dltotal, dlnow, ultotal, ulnow);
+  return 0;
 }

--- a/source/helpers.cc
+++ b/source/helpers.cc
@@ -100,8 +100,10 @@ size_t RestClient::Helpers::read_callback(void *data, size_t size,
  * @param ultotal total upload size in bytes
  * @param ulnow already downloaded bytes
  */
-int RestClient::Helpers::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
-  RestClient::ProgressCallback *callBackPtr = (RestClient::ProgressCallback *)clientp;
+int RestClient::Helpers::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
+        curl_off_t ultotal, curl_off_t ulnow) {
+  RestClient::ProgressCallback *callBackPtr =
+          (RestClient::ProgressCallback *)clientp;
   (*callBackPtr)(dltotal, dlnow, ultotal, ulnow);
   return 0;
 }

--- a/source/helpers.cc
+++ b/source/helpers.cc
@@ -100,8 +100,8 @@ size_t RestClient::Helpers::read_callback(void *data, size_t size,
  * @param ultotal total upload size in bytes
  * @param ulnow already downloaded bytes
  */
-int RestClient::Helpers::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
-        curl_off_t ultotal, curl_off_t ulnow) {
+int RestClient::Helpers::progress_callback(void *clientp, curl_off_t dltotal,
+        curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
   RestClient::ProgressCallback *callBackPtr =
           (RestClient::ProgressCallback *)clientp;
   (*callBackPtr)(dltotal, dlnow, ultotal, ulnow);

--- a/test/test_restclient.cc
+++ b/test/test_restclient.cc
@@ -50,7 +50,7 @@ TEST_F(RestClientTest, TestRestClientDeleteFailureCode)
 {
   std::string u = "http://nonexistent";
   RestClient::Response res = RestClient::del(u);
-  EXPECT_EQ(-1, res.code);
+  EXPECT_EQ(-CURLE_COULDNT_RESOLVE_HOST, res.code);
 }
 TEST_F(RestClientTest, TestRestClientDeleteHeaders)
 {
@@ -80,8 +80,8 @@ TEST_F(RestClientTest, TestRestClientGETFailureCode)
 {
   std::string u = "http://nonexistent";
   RestClient::Response res = RestClient::get(u);
-  EXPECT_EQ("Failed to query.", res.body);
-  EXPECT_EQ(-1, res.code);
+  EXPECT_EQ("Failed to query; curl error code: 6", res.body);
+  EXPECT_EQ(-CURLE_COULDNT_RESOLVE_HOST, res.code);
 }
 
 TEST_F(RestClientTest, TestRestClientGETHeaders)
@@ -112,7 +112,7 @@ TEST_F(RestClientTest, TestRestClientPOSTFailureCode)
 {
   std::string u = "http://nonexistent";
   RestClient::Response res = RestClient::post(u, "text/text", "data");
-  EXPECT_EQ(-1, res.code);
+  EXPECT_EQ(-CURLE_COULDNT_RESOLVE_HOST, res.code);
 }
 TEST_F(RestClientTest, TestRestClientPOSTHeaders)
 {
@@ -142,7 +142,8 @@ TEST_F(RestClientTest, TestRestClientPUTFailureCode)
 {
   std::string u = "http://nonexistent";
   RestClient::Response res = RestClient::put(u, "text/text", "data");
-  EXPECT_EQ(-1, res.code);
+  EXPECT_EQ(-CURLE_COULDNT_RESOLVE_HOST, res.code);
+
 }
 TEST_F(RestClientTest, TestRestClientPUTHeaders)
 {

--- a/test/testdata.txt
+++ b/test/testdata.txt
@@ -1,0 +1,2 @@
+This is a simple file with some data for uploading during
+tests.


### PR DESCRIPTION
Main content of this PR is the possibility to download and upload data directly to / from files instead of keeping it in memory in the Response object. Additionally there is a possibility to install a progress callback to track the amount of data sent or received.

I extended the error handling a bit as well. Before the change the Response.code contains either the HTTP response code, the value of 28 (in case of a timeout), or -1 in case of other errors. I changed it to contain either the HTTP code, or a negative value containing the curl error code.

Detailed changes:
- Support for streaming the request body from a file and the response body to a file - useful for uploads and downloads
- Possibility to install a progress callback
- Added C compiler flag to use C++11 (needed for progress callback which is a std::function)
- Added possibility to set a debug proxy for inspecting request / response traffic
- Extended error handling: The response code contains either the HTTP code, or a negative value containing the curl error code. 
- Unit tests for the above
- Updated README.md



