### PR TITLE
no-signal capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ your threads. Do not share connection objects across threads as this would
 mean accessing curl handles from multiple threads at the same time which is
 not allowed.
 
+The connection level method SetNoSignal can be set to skip all signal handling. This is important in multi-threaded applications as DNS resolution timeouts use signals. The signal handlers quite readily get executed on other threads. Note that with this option DNS resolution timeouts do not work. If you have crashes in your multi-threaded executable that appear to be in DNS resolution, this is probably why.
+
 In order to provide an easy to use API, the simple usage via the static
 methods implicitly calls the curl global functions and is therefore also **not
 thread-safe**.

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -95,6 +95,7 @@ class Connection {
       RestClient::HeaderFields headers;
       int timeout;
       bool followRedirects;
+      bool noSignal;
       struct {
         std::string username;
         std::string password;
@@ -114,6 +115,9 @@ class Connection {
 
     // set connection timeout to seconds
     void SetTimeout(int seconds);
+
+    // set to not use signals
+    void SetNoSignal(bool no);
 
     // set whether to follow redirects
     void FollowRedirects(bool follow);
@@ -156,6 +160,7 @@ class Connection {
     RestClient::HeaderFields headerFields;
     int timeout;
     bool followRedirects;
+    bool noSignal;
     struct {
       std::string username;
       std::string password;

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -34,6 +34,7 @@ RestClient::Connection::Connection(const std::string& baseUrl)
   this->baseUrl = baseUrl;
   this->timeout = 0;
   this->followRedirects = false;
+  this->noSignal = false;
 }
 
 RestClient::Connection::~Connection() {
@@ -55,6 +56,8 @@ RestClient::Connection::GetInfo() {
   ret.baseUrl = this->baseUrl;
   ret.headers = this->GetHeaders();
   ret.timeout = this->timeout;
+  ret.followRedirects = this->followRedirects;
+  ret.noSignal = this->noSignal;
   ret.basicAuth.username = this->basicAuth.username;
   ret.basicAuth.password = this->basicAuth.password;
   ret.customUserAgent = this->customUserAgent;
@@ -162,6 +165,18 @@ RestClient::Connection::SetTimeout(int seconds) {
 }
 
 /**
+ * @brief switch off curl signals for connection (see CURLOPT_NONSIGNAL). By
+ * default signals are used, except when timeout is given.
+ *
+ * @param no - set to true switches signals off
+ *
+ */
+void
+RestClient::Connection::SetNoSignal(bool no) {
+  this->noSignal = no;
+}
+
+/**
  * @brief set username and password for basic auth
  *
  * @param username
@@ -242,6 +257,12 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
   if (this->followRedirects == true) {
     curl_easy_setopt(this->curlHandle, CURLOPT_FOLLOWLOCATION, 1L);
   }
+
+  if (this->noSignal) {
+    // multi-threaded and prevent entering foreign signal handler (e.g. JNI)
+    curl_easy_setopt(this->curlHandle, CURLOPT_NOSIGNAL, 1);
+  }
+
   // if provided, supply CA path
   if (!this->caInfoFilePath.empty()) {
     curl_easy_setopt(this->curlHandle, CURLOPT_CAINFO,

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -197,3 +197,10 @@ TEST_F(ConnectionTest, TestHeadHeaders)
   EXPECT_EQ("bar", headers_returned["Foo"]);
   EXPECT_EQ("lol", headers_returned["Bla"]);
 }
+
+TEST_F(ConnectionTest, TestNoSignal)
+{
+  conn->SetNoSignal(true);
+  RestClient::Response res = conn->get("/get");
+  EXPECT_EQ(200, res.code);
+}


### PR DESCRIPTION
I've added the ability to explicitly flag CURLOPT_NOSIGNAL. This is useful in multi-threaded use cases and in other cases where signals are being used. e.g. JNI; the JVM uses signals for all kinds of things internally and installing more signal handlers often leads to nasty results.

In my case my problem was that the DNS resolver library on my system (OpenBSD) was interfering with CURL.