### PR TITLE
HTTP Proxy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ conn->SetCertPath(certPath);
 conn->SetCertType(type);
 // set CURLOPT_SSLKEY
 conn->SetKeyPath(keyPath);
+// set CURLOPT_KEYPASSWD
+conn->SetKeyPassword(keyPassword);
 ```
 
 ## HTTP Proxy Tunneling Support

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ conn->SetCertType(type);
 conn->SetKeyPath(keyPath);
 ```
 
+## HTTP Proxy Tunneling Support
+
+An HTTP Proxy can be set to use for the upcoming request.
+To specify a port number, append :[port] to the end of the host name. If not specified, `libcurl` will default to using port 1080 for proxies. The proxy string may be prefixed with `http://` or `https://`. If no HTTP(S) scheme is specified, the address provided to `libcurl` will be prefixed with `http://` to specify an HTTP proxy. A proxy host string can embedded user + password.
+The operation will be tunneled through the proxy as curl option `CURLOPT_HTTPPROXYTUNNEL` is enabled by default.
+A numerical IPv6 address must be written within [brackets].
+
+```cpp
+// set CURLOPT_PROXY
+conn->SetProxy("https://37.187.100.23:3128");
+/* or you can set it without the protocol scheme and
+http:// will be prefixed by default */
+conn->SetProxy("37.187.100.23:3128");
+/* the following request will be tunneled through the proxy */
+RestClient::Response res = conn->get("/get");
+```
+
 ## Dependencies
 - [libcurl][]
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ typedef struct {
   std::string certPath;
   std::string certType;
   std::string keyPath;
+  std::string keyPassword;
   std::string customUserAgent;
+  std::string uriProxy;
   struct {
     // total time of the last request in seconds Total time of previous
     // transfer. See CURLINFO_TOTAL_TIME

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -85,8 +85,18 @@ class Connection {
       *  Member 'username' contains the basic auth username
       *  @var basicAuth::password
       *  Member 'password' contains the basic auth password
+      *  @var Info::certPath
+      *  Member 'certPath' contains the certificate file path
+      *  @var Info::certType
+      *  Member 'certType' contains the certificate type
+      *  @var Info::keyPath
+      *  Member 'keyPath' contains the SSL key file path
+      *  @var Info::keyPassword
+      *  Member 'keyPassword' contains the SSL key password
       *  @var Info::customUserAgent
       *  Member 'customUserAgent' contains the custom user agent
+      *  @var Info::uriProxy
+      *  Member 'uriProxy' contains the HTTP proxy address
       *  @var Info::lastRequest
       *  Member 'lastRequest' contains metrics about the last request
       */
@@ -104,6 +114,7 @@ class Connection {
       std::string certPath;
       std::string certType;
       std::string keyPath;
+      std::string keyPassword;
       std::string customUserAgent;
       std::string uriProxy;
       RequestInfo lastRequest;
@@ -143,6 +154,9 @@ class Connection {
 
     // set CURLOPT_SSLKEY. Default format is PEM
     void SetKeyPath(const std::string& keyPath);
+
+    // set CURLOPT_KEYPASSWD.
+    void SetKeyPassword(const std::string& keyPassword);
 
     // set CURLOPT_PROXY
     void SetProxy(const std::string& uriProxy);
@@ -188,6 +202,7 @@ class Connection {
     std::string certPath;
     std::string certType;
     std::string keyPath;
+    std::string keyPassword;
     std::string uriProxy;
     RestClient::Response performCurlRequest(const std::string& uri);
 };

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -105,6 +105,7 @@ class Connection {
       std::string certType;
       std::string keyPath;
       std::string customUserAgent;
+      std::string uriProxy;
       RequestInfo lastRequest;
     } Info;
 
@@ -142,6 +143,9 @@ class Connection {
 
     // set CURLOPT_SSLKEY. Default format is PEM
     void SetKeyPath(const std::string& keyPath);
+
+    // set CURLOPT_PROXY
+    void SetProxy(const std::string& uriProxy);
 
     std::string GetUserAgent();
 
@@ -184,6 +188,7 @@ class Connection {
     std::string certPath;
     std::string certType;
     std::string keyPath;
+    std::string uriProxy;
     RestClient::Response performCurlRequest(const std::string& uri);
 };
 };  // namespace RestClient

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -66,6 +66,7 @@ RestClient::Connection::GetInfo() {
   ret.certPath = this->certPath;
   ret.certType = this->certType;
   ret.keyPath = this->keyPath;
+  ret.keyPassword = this->keyPassword;
 
   ret.uriProxy = this->uriProxy;
 
@@ -196,21 +197,56 @@ RestClient::Connection::SetBasicAuth(const std::string& username,
   this->basicAuth.password = password;
 }
 
+/**
+ * @brief set certificate path
+ *
+ * @param path to certificate file
+ *
+ */
 void
 RestClient::Connection::SetCertPath(const std::string& cert) {
   this->certPath = cert;
 }
 
+/**
+ * @brief set certificate type
+ *
+ * @param certificate type (e.g. "PEM" or "DER")
+ *
+ */
 void
 RestClient::Connection::SetCertType(const std::string& certType) {
   this->certType = certType;
 }
 
+/**
+ * @brief set key path
+ *
+ * @param path to key file
+ *
+ */
 void
 RestClient::Connection::SetKeyPath(const std::string& keyPath) {
   this->keyPath = keyPath;
 }
 
+/**
+ * @brief set key password
+ *
+ * @param key password
+ *
+ */
+void
+RestClient::Connection::SetKeyPassword(const std::string& keyPassword) {
+  this->keyPassword = keyPassword;
+}
+
+/**
+ * @brief set HTTP proxy address and port
+ *
+ * @param proxy address with port number
+ *
+ */
 void
 RestClient::Connection::SetProxy(const std::string& uriProxy) {
   if (uriProxy.empty()) {
@@ -323,6 +359,11 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
   if (!this->keyPath.empty()) {
     curl_easy_setopt(this->curlHandle, CURLOPT_SSLKEY,
                      this->keyPath.c_str());
+  }
+  // set key password
+  if (!this->keyPassword.empty()) {
+    curl_easy_setopt(this->curlHandle, CURLOPT_KEYPASSWD,
+                     this->keyPassword.c_str());
   }
 
   // set web proxy address

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -217,7 +217,8 @@ RestClient::Connection::SetProxy(const std::string& uriProxy) {
     return;
 
   std::string uriProxyUpper = uriProxy;
-  std::transform(uriProxyUpper.begin(), uriProxyUpper.end(), uriProxyUpper.begin(), ::toupper);
+  std::transform(uriProxyUpper.begin(), uriProxyUpper.end(),
+    uriProxyUpper.begin(), ::toupper);
 
   if (uriProxyUpper.compare(0, 4, "HTTP") != 0)
     this->uriProxy = "http://" + uriProxy;

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -213,17 +213,20 @@ RestClient::Connection::SetKeyPath(const std::string& keyPath) {
 
 void
 RestClient::Connection::SetProxy(const std::string& uriProxy) {
-  if (uriProxy.empty())
+  if (uriProxy.empty()) {
     return;
+  }
 
   std::string uriProxyUpper = uriProxy;
+  // check if the provided address is prefixed with "http"
   std::transform(uriProxyUpper.begin(), uriProxyUpper.end(),
     uriProxyUpper.begin(), ::toupper);
 
-  if (uriProxyUpper.compare(0, 4, "HTTP") != 0)
+  if (uriProxyUpper.compare(0, 4, "HTTP") != 0) {
     this->uriProxy = "http://" + uriProxy;
-  else
+  } else {
     this->uriProxy = uriProxy;
+  }
 }
 
 /**

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -96,6 +96,7 @@ TEST_F(ConnectionTest, TestSSLCert)
 {
   conn->SetCertPath("non-existent file");
   conn->SetKeyPath("non-existent key path");
+  conn->SetKeyPassword("imaginary_password");
   conn->SetCertType("invalid cert type");
   RestClient::Response res = conn->get("/get");
 

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -221,3 +221,11 @@ TEST_F(ConnectionTest, TestProxy)
   RestClient::Response res = conn->get("/get");
   EXPECT_EQ(200, res.code);
 }
+
+TEST_F(ConnectionTest, TestInvalidProxy)
+{
+  conn->SetProxy("127.0.0.1:666");
+  RestClient::Response res = conn->get("/get");
+  EXPECT_EQ("Failed to query.", res.body);
+  EXPECT_EQ(-1, res.code);
+}

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -214,3 +214,10 @@ TEST_F(ConnectionTest, TestNoSignal)
   RestClient::Response res = conn->get("/get");
   EXPECT_EQ(200, res.code);
 }
+
+TEST_F(ConnectionTest, TestProxy)
+{
+  conn->SetProxy("37.187.79.19:3128");
+  RestClient::Response res = conn->get("/get");
+  EXPECT_EQ(200, res.code);
+}

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -217,7 +217,14 @@ TEST_F(ConnectionTest, TestNoSignal)
 
 TEST_F(ConnectionTest, TestProxy)
 {
-  conn->SetProxy("37.187.79.19:3128");
+  conn->SetProxy("37.187.100.23:3128");
+  RestClient::Response res = conn->get("/get");
+  EXPECT_EQ(200, res.code);
+}
+
+TEST_F(ConnectionTest, TestProxyAddressPrefixed)
+{
+  conn->SetProxy("https://37.187.100.23:3128");
   RestClient::Response res = conn->get("/get");
   EXPECT_EQ(200, res.code);
 }


### PR DESCRIPTION
I added and tested a method to set a web HTTP proxy address and to tunnel an operation through it.
If the provided proxy address is invalid, the operation will fail and it's confirmed with the unit test "TestInvalidProxy".

The test I wrote (TestProxy) is based on a hard-coded proxy address from https://www.sslproxies.org/ 

Personally, in my Google Test unit tests, I parse a configuration file (via simpleini API) to fetch test environment parameters (proxy/URL addresses, local paths...), this technique can be used to update the proxy address used in the unit test if it's not valid anymore and it will offer versatility for the other parameters used in the other unit tests.