### PR TITLE
add proxy server as docker service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,21 @@ language: cpp
 dist: trusty
 sudo: required
 group: beta
+
+services:
+  - docker
+
 compiler:
   - gcc
   - clang
 script:
   - ./autogen.sh && ./configure --enable-coverage
   - make ci
+
+before_install:
+  - docker pull chrisdaish/squid
+  - docker run -d -p 3128:3128 chrisdaish/squid
+  - docker ps -a
 install:
 - gem install fpm
 - gem install package_cloud

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -219,14 +219,14 @@ TEST_F(ConnectionTest, TestNoSignal)
 
 TEST_F(ConnectionTest, TestProxy)
 {
-  conn->SetProxy("37.187.100.23:3128");
+  conn->SetProxy("127.0.0.1:3128");
   RestClient::Response res = conn->get("/get");
   EXPECT_EQ(200, res.code);
 }
 
 TEST_F(ConnectionTest, TestProxyAddressPrefixed)
 {
-  conn->SetProxy("https://37.187.100.23:3128");
+  conn->SetProxy("https://127.0.0.1:3128");
   RestClient::Response res = conn->get("/get");
   EXPECT_EQ(200, res.code);
 }


### PR DESCRIPTION
this makes the tests rely on a dockerized proxy service instead of a
random server on the internet