### PR TITLE
Add PATCH and OPTIONS methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,7 @@ config*
 *aclocal.m4
 *Makefile
 *Makefile.in
-vendor/gtest-1.7.0/scripts/gtest-config
-vendor/gtest-1.7.0/build-aux/config.h
-vendor/gtest-1.7.0/build-aux/config.h.in
-vendor/gtest-1.7.0/build-aux/ltmain.sh
-vendor/gtest-1.7.0/m4/ltoptions.m4
-vendor/gtest-1.7.0/m4/ltversion.m4
-vendor/jsoncpp-0.10.5/dist/.deps/jsoncpp.Po
+vendor/*
 test-program
 .libs
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ verbs:
 RestClient::Response r = RestClient::get("http://url.com")
 RestClient::Response r = RestClient::post("http://url.com/post", "application/json", "{\"foo\": \"bla\"}")
 RestClient::Response r = RestClient::put("http://url.com/put", "application/json", "{\"foo\": \"bla\"}")
+RestClient::Response r = RestClient::patch("http://url.com/patch", "application/json", "{\"foo\": \"bla\"}")
 RestClient::Response r = RestClient::del("http://url.com/delete")
 RestClient::Response r = RestClient::head("http://url.com")
+RestClient::Response r = RestClient::options("http://url.com")
 ```
 
 The response is of type [RestClient::Response][restclient_response] and has
@@ -82,11 +84,13 @@ conn->SetCAInfoFilePath("/etc/custom-ca.crt")
 RestClient::Response r = conn->get("/get")
 RestClient::Response r = conn->head("/get")
 RestClient::Response r = conn->del("/delete")
+RestClient::Response r = conn->options("/options")
 
-// set different content header for POST and PUT
+// set different content header for POST, PUT and PATCH
 conn->AppendHeader("Content-Type", "application/json")
 RestClient::Response r = conn->post("/post", "{\"foo\": \"bla\"}")
 RestClient::Response r = conn->put("/put", "application/json", "{\"foo\": \"bla\"}")
+RestClient::Response r = conn->patch("/patch", "text/plain", "foobar")
 
 // deinit RestClient. After calling this you have to call RestClient::init()
 // again before you can use it

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -188,8 +188,11 @@ class Connection {
                               const std::string& data);
     RestClient::Response put(const std::string& uri,
                              const std::string& data);
+    RestClient::Response patch(const std::string& uri,
+                             const std::string& data);
     RestClient::Response del(const std::string& uri);
     RestClient::Response head(const std::string& uri);
+    RestClient::Response options(const std::string& uri);
 
  private:
     CURL* curlHandle;

--- a/include/restclient-cpp/restclient.h
+++ b/include/restclient-cpp/restclient.h
@@ -56,8 +56,12 @@ Response post(const std::string& url,
 Response put(const std::string& url,
               const std::string& content_type,
               const std::string& data);
+Response patch(const std::string& url,
+              const std::string& content_type,
+              const std::string& data);
 Response del(const std::string& url);
 Response head(const std::string& url);
+Response options(const std::string& url);
 
 }  // namespace RestClient
 

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -492,6 +492,39 @@ RestClient::Connection::put(const std::string& url,
   return this->performCurlRequest(url);
 }
 /**
+ * @brief HTTP PATCH method
+ *
+ * @param url to query
+ * @param data HTTP PATCH body
+ *
+ * @return response struct
+ */
+RestClient::Response
+RestClient::Connection::patch(const std::string& url,
+                            const std::string& data) {
+  /** initialize upload object */
+  RestClient::Helpers::UploadObject up_obj;
+  up_obj.data = data.c_str();
+  up_obj.length = data.size();
+
+  /** we want HTTP PATCH */
+  const char* http_patch = "PATCH";
+
+  /** set HTTP PATCH METHOD */
+  curl_easy_setopt(this->curlHandle, CURLOPT_CUSTOMREQUEST, http_patch);
+  curl_easy_setopt(this->curlHandle, CURLOPT_UPLOAD, 1L);
+  /** set read callback function */
+  curl_easy_setopt(this->curlHandle, CURLOPT_READFUNCTION,
+                   RestClient::Helpers::read_callback);
+  /** set data object to pass to callback function */
+  curl_easy_setopt(this->curlHandle, CURLOPT_READDATA, &up_obj);
+  /** set data size */
+  curl_easy_setopt(this->curlHandle, CURLOPT_INFILESIZE,
+                     static_cast<int64_t>(up_obj.length));
+
+  return this->performCurlRequest(url);
+}
+/**
  * @brief HTTP DELETE method
  *
  * @param url to query
@@ -523,6 +556,25 @@ RestClient::Connection::head(const std::string& url) {
 
     /** set HTTP HEAD METHOD */
     curl_easy_setopt(this->curlHandle, CURLOPT_CUSTOMREQUEST, http_head);
+    curl_easy_setopt(this->curlHandle, CURLOPT_NOBODY, 1L);
+
+    return this->performCurlRequest(url);
+}
+
+/**
+ * @brief HTTP OPTIONS method
+ *
+ * @param url to query
+ *
+ * @return response struct
+ */
+RestClient::Response
+RestClient::Connection::options(const std::string& url) {
+    /** we want HTTP OPTIONS */
+    const char* http_options = "OPTIONS";
+
+    /** set HTTP HEAD METHOD */
+    curl_easy_setopt(this->curlHandle, CURLOPT_CUSTOMREQUEST, http_options);
     curl_easy_setopt(this->curlHandle, CURLOPT_NOBODY, 1L);
 
     return this->performCurlRequest(url);

--- a/source/restclient.cc
+++ b/source/restclient.cc
@@ -94,6 +94,26 @@ RestClient::Response RestClient::put(const std::string& url,
 }
 
 /**
+ * @brief HTTP PATCH method
+ *
+ * @param url to query
+ * @param ctype content type as string
+ * @param data HTTP PATCH body
+ *
+ * @return response struct
+ */
+RestClient::Response RestClient::patch(const std::string& url,
+                                     const std::string& ctype,
+                                     const std::string& data) {
+  RestClient::Response ret;
+  RestClient::Connection *conn = new RestClient::Connection("");
+  conn->AppendHeader("Content-Type", ctype);
+  ret = conn->patch(url, data);
+  delete conn;
+  return ret;
+}
+
+/**
  * @brief HTTP DELETE method
  *
  * @param url to query
@@ -119,6 +139,21 @@ RestClient::Response RestClient::head(const std::string& url) {
   RestClient::Response ret;
   RestClient::Connection *conn = new RestClient::Connection("");
   ret = conn->head(url);
+  delete conn;
+  return ret;
+}
+
+/**
+ * @brief HTTP OPTIONS method
+ *
+ * @param url to query
+ *
+ * @return response struct
+ */
+RestClient::Response RestClient::options(const std::string& url) {
+  RestClient::Response ret;
+  RestClient::Connection *conn = new RestClient::Connection("");
+  ret = conn->options(url);
   delete conn;
   return ret;
 }

--- a/test/test_restclient.cc
+++ b/test/test_restclient.cc
@@ -29,12 +29,13 @@ class RestClientTest : public ::testing::Test
 
 // DELETE Tests
 // check return code
-TEST_F(RestClientTest, TestRestClientDeleteCode)
+TEST_F(RestClientTest, TestRestClientDELETECode)
 {
   RestClient::Response res = RestClient::del("http://httpbin.org/delete");
   EXPECT_EQ(200, res.code);
 }
-TEST_F(RestClientTest, TestRestClientDeleteBody)
+
+TEST_F(RestClientTest, TestRestClientDELETEBody)
 {
   RestClient::Response res = RestClient::del("http://httpbin.org/delete");
   Json::Value root;
@@ -46,13 +47,14 @@ TEST_F(RestClientTest, TestRestClientDeleteBody)
 }
 
 // check for failure
-TEST_F(RestClientTest, TestRestClientDeleteFailureCode)
+TEST_F(RestClientTest, TestRestClientDELETEFailureCode)
 {
   std::string u = "http://nonexistent";
   RestClient::Response res = RestClient::del(u);
   EXPECT_EQ(-1, res.code);
 }
-TEST_F(RestClientTest, TestRestClientDeleteHeaders)
+
+TEST_F(RestClientTest, TestRestClientDELETEHeaders)
 {
   RestClient::Response res = RestClient::del("http://httpbin.org/delete");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
@@ -64,11 +66,13 @@ TEST_F(RestClientTest, TestRestClientGETCode)
   RestClient::Response res = RestClient::get("http://httpbin.org/get");
   EXPECT_EQ(200, res.code);
 }
+
 TEST_F(RestClientTest, TestRestClientGETHTTP2Code)
 {
   RestClient::Response res = RestClient::get("https://http2.golang.org/reqinfo");
   EXPECT_EQ(200, res.code);
 }
+
 TEST_F(RestClientTest, TestRestClientGETBodyCode)
 {
   RestClient::Response res = RestClient::get("http://httpbin.org/get");
@@ -102,7 +106,8 @@ TEST_F(RestClientTest, TestRestClientPOSTCode)
   RestClient::Response res = RestClient::post("http://httpbin.org/post", "text/text", "data");
   EXPECT_EQ(200, res.code);
 }
-TEST_F(RestClientTest, TestRestClientPostBody)
+
+TEST_F(RestClientTest, TestRestClientPOSTBody)
 {
   RestClient::Response res = RestClient::post("http://httpbin.org/post", "text/text", "data");
   Json::Value root;
@@ -112,6 +117,7 @@ TEST_F(RestClientTest, TestRestClientPostBody)
   EXPECT_EQ("http://httpbin.org/post", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
+
 // check for failure
 TEST_F(RestClientTest, TestRestClientPOSTFailureCode)
 {
@@ -119,6 +125,7 @@ TEST_F(RestClientTest, TestRestClientPOSTFailureCode)
   RestClient::Response res = RestClient::post(u, "text/text", "data");
   EXPECT_EQ(-1, res.code);
 }
+
 TEST_F(RestClientTest, TestRestClientPOSTHeaders)
 {
   RestClient::Response res = RestClient::post("http://httpbin.org/post", "text/text", "data");
@@ -132,7 +139,8 @@ TEST_F(RestClientTest, TestRestClientPUTCode)
   RestClient::Response res = RestClient::put("http://httpbin.org/put", "text/text", "data");
   EXPECT_EQ(200, res.code);
 }
-TEST_F(RestClientTest, TestRestClientPutBody)
+
+TEST_F(RestClientTest, TestRestClientPUTBody)
 {
   RestClient::Response res = RestClient::put("http://httpbin.org/put", "text/text", "data");
   Json::Value root;
@@ -142,6 +150,7 @@ TEST_F(RestClientTest, TestRestClientPutBody)
   EXPECT_EQ("http://httpbin.org/put", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
+
 // check for failure
 TEST_F(RestClientTest, TestRestClientPUTFailureCode)
 {
@@ -149,11 +158,69 @@ TEST_F(RestClientTest, TestRestClientPUTFailureCode)
   RestClient::Response res = RestClient::put(u, "text/text", "data");
   EXPECT_EQ(-1, res.code);
 }
+
 TEST_F(RestClientTest, TestRestClientPUTHeaders)
 {
   RestClient::Response res = RestClient::put("http://httpbin.org/put", "text/text", "data");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
+
+// PATCH Tests
+// check return code
+TEST_F(RestClientTest, TestRestClientPATCHCode)
+{
+  RestClient::Response res = RestClient::patch("http://httpbin.org/patch", "text/text", "data");
+  EXPECT_EQ(200, res.code);
+}
+
+TEST_F(RestClientTest, TestRestClientPATCHBody)
+{
+  RestClient::Response res = RestClient::patch("http://httpbin.org/patch", "text/text", "data");
+  Json::Value root;
+  std::istringstream str(res.body);
+  str >> root;
+
+  EXPECT_EQ("http://httpbin.org/patch", root.get("url", "no url set").asString());
+  EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
+}
+
+// check for failure
+TEST_F(RestClientTest, TestRestClientPATCHFailureCode)
+{
+  std::string u = "http://nonexistent";
+  RestClient::Response res = RestClient::patch(u, "text/text", "data");
+  EXPECT_EQ(-1, res.code);
+}
+
+TEST_F(RestClientTest, TestRestClientPATCHHeaders)
+{
+  RestClient::Response res = RestClient::patch("http://httpbin.org/put", "text/text", "data");
+  EXPECT_EQ("keep-alive", res.headers["Connection"]);
+}
+
+// OPTIONS Tests
+// check return code
+// Disabled as httpbin does not support options requests for now
+TEST_F(RestClientTest, DISABLED_TestRestClientOPTIONSCode)
+{
+  RestClient::Response res = RestClient::options("http://httpbin.org/options");
+  EXPECT_EQ(200, res.code);
+}
+
+// check for failure
+TEST_F(RestClientTest, TestRestClientOPTIONSFailureCode)
+{
+  std::string u = "http://nonexistent";
+  RestClient::Response res = RestClient::options(u);
+  EXPECT_EQ(-1, res.code);
+}
+
+TEST_F(RestClientTest, TestRestClientOPTIONSHeaders)
+{
+  RestClient::Response res = RestClient::options("http://httpbin.org/options");
+  EXPECT_EQ("keep-alive", res.headers["Connection"]);
+}
+
 TEST_F(RestClientTest, TestRestClientAuth)
 {
   RestClient::Response res = RestClient::get("http://foo:bar@httpbin.org/basic-auth/foo/bar");
@@ -169,6 +236,7 @@ TEST_F(RestClientTest, TestRestClientAuth)
   res = RestClient::get("http://httpbin.org/basic-auth/foo/bar");
   EXPECT_EQ(401, res.code);
 }
+
 TEST_F(RestClientTest, TestRestClientHeadCode)
 {
   RestClient::Response res = RestClient::head("http://httpbin.org/get");


### PR DESCRIPTION
Add support for HTTP PATCH and OPTIONS methods for the client. Unfortunately the httpbin does not support OPTIONS method (for now) so the test is disabled.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [x] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [x] Unit tests for the proposed change
