### PR TITLE
Added support for Unix sockets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,23 @@ conn->SetProxy("37.187.100.23:3128");
 RestClient::Response res = conn->get("/get");
 ```
 
+## Unix Socket Support
+
+- https://docs.docker.com/develop/sdk/examples/
+- $ curl --unix-socket /var/run/docker.sock http:/v1.24/containers/json
+
+Note that the URL used with a unix socket has only ONE leading forward slash.
+
+```cpp
+RestClient::Connection* conn = new RestClient::Connection("http:/v1.30");
+conn->SetUnixSocketPath("/var/run/docker.sock");
+RestClient::HeaderFields headers;
+headers["Accept"] = "application/json; charset=UTF-8";
+headers["Expect"] = "";
+conn->SetHeaders(headers);
+auto resp = conn->get("/images/json");
+```
+
 ## Dependencies
 - [libcurl][]
 

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -120,6 +120,7 @@ class Connection {
       std::string keyPassword;
       std::string customUserAgent;
       std::string uriProxy;
+      std::string unixSocketPath;
       RequestInfo lastRequest;
     } Info;
 
@@ -164,6 +165,9 @@ class Connection {
 
     // set CURLOPT_PROXY
     void SetProxy(const std::string& uriProxy);
+
+    // set CURLOPT_UNIX_SOCKET_PATH
+    void SetUnixSocketPath(const std::string& unixSocketPath);
 
     std::string GetUserAgent();
 
@@ -212,6 +216,7 @@ class Connection {
     std::string keyPath;
     std::string keyPassword;
     std::string uriProxy;
+    std::string unixSocketPath;
     RestClient::Response performCurlRequest(const std::string& uri);
 };
 };  // namespace RestClient

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -71,6 +71,7 @@ RestClient::Connection::GetInfo() {
   ret.keyPassword = this->keyPassword;
 
   ret.uriProxy = this->uriProxy;
+  ret.unixSocketPath = this->unixSocketPath;
 
   return ret;
 }
@@ -266,6 +267,19 @@ RestClient::Connection::SetProxy(const std::string& uriProxy) {
 }
 
 /**
+ * @brief set custom Unix socket path for connection.
+ * See https://curl.haxx.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html
+ *
+ * @param unixSocketPath - path to Unix socket (ex: /var/run/docker.sock)
+ *
+ */
+void
+RestClient::Connection::SetUnixSocketPath(const std::string& unixSocketPath) {
+  this->unixSocketPath = unixSocketPath;
+}
+
+
+/**
  * @brief helper function to get called from the actual request methods to
  * prepare the curlHandle for transfer with generic options, perform the
  * request and record some stats from the last request and then reset the
@@ -374,6 +388,12 @@ RestClient::Connection::performCurlRequest(const std::string& uri) {
                      uriProxy.c_str());
     curl_easy_setopt(this->curlHandle, CURLOPT_HTTPPROXYTUNNEL,
                      1L);
+  }
+
+  // set Unix socket path, if requested
+  if (!this->unixSocketPath.empty()) {
+    curl_easy_setopt(this->curlHandle, CURLOPT_UNIX_SOCKET_PATH,
+                     this->unixSocketPath.c_str());
   }
 
   res = curl_easy_perform(this->curlHandle);


### PR DESCRIPTION
Added method `RestClient::Connection::SetUnixSocketPath()`, which triggers call to `curl_easy_setopt(foo, CURLOPT_UNIX_SOCKET_PATH, bar)`

Tested with my own project which uses restclient-cpp to connect to Docker over its unix socket ("/var/run/docker.sock") and pull a list of images.

I did not add a unit test because the existing unit tests are not hermetic, and it is a bit complex to stand up an HTTP server on a unix socket (I supposed form/exec nginx would do).