### PR TITLE
mac os x uses glibtoolize not libtoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,15 @@
 #! /bin/sh
 [ -e config.cache ] && rm -f config.cache
 
-libtoolize --automake
+echo -n "testing for glibtoolize ... "
+if glibtoolize --version >/dev/null 2>&1; then
+  LIBTOOLIZE=glibtoolize
+  echo "using glibtoolize"
+else
+  LIBTOOLIZE=libtoolize
+  echo "using libtoolize"
+fi
+$LIBTOOLIZE --automake
 aclocal ${OECORE_ACLOCAL_OPTS}
 autoconf
 autoheader


### PR DESCRIPTION
for mac os x hosts "libtoolize" is not a correct command.
this is because mac bundles it's own version of "libtool",
which works differently, and may not even exist.

instead if you use brew to install libtool: `brew install libtool`
on mac, it writes to: `glibtoolize` as to leave mac happy with
it's own version of libtool by default.

this commit will properly use glibtoolize if detected, otherwise
will fallback to just using libtoolize.
