### PR TITLE
use lambda's over ptr_fun

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(test-program
   test/tests.cpp
   test/test_restclient.cc
   test/test_connection.cc
+  test/test_helpers.cc
 )
 target_include_directories(test-program
   PRIVATE include

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ test_program_CPPFLAGS=-Iinclude -Ivendor/gtest-1.7.0/include -Ivendor/jsoncpp-0.
 
 lib_LTLIBRARIES=librestclient-cpp.la
 librestclient_cpp_la_SOURCES=source/restclient.cc source/connection.cc source/helpers.cc
-librestclient_cpp_la_CXXFLAGS=-fPIC
+librestclient_cpp_la_CXXFLAGS=-fPIC -std=c++11
 librestclient_cpp_la_LDFLAGS=-version-info 2:1:1
 
 dist_doc_DATA = README.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ BUILT_SOURCES = include/restclient-cpp/version.h
 test_program_SOURCES = vendor/jsoncpp-0.10.5/dist/jsoncpp.cpp test/tests.cpp test/test_helpers.cc test/test_restclient.cc test/test_connection.cc
 test_program_LDADD = .libs/librestclient-cpp.a
 test_program_LDFLAGS=-Lvendor/gtest-1.7.0/lib/.libs -lgtest
-test_program_CPPFLAGS=-Iinclude -Ivendor/gtest-1.7.0/include -Ivendor/jsoncpp-0.10.5/dist
+test_program_CPPFLAGS=-std=c++11 -Iinclude -Ivendor/gtest-1.7.0/include -Ivendor/jsoncpp-0.10.5/dist
 
 lib_LTLIBRARIES=librestclient-cpp.la
 librestclient_cpp_la_SOURCES=source/restclient.cc source/connection.cc source/helpers.cc

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ check_PROGRAMS = test-program
 pkginclude_HEADERS = include/restclient-cpp/restclient.h include/restclient-cpp/version.h include/restclient-cpp/connection.h include/restclient-cpp/helpers.h
 BUILT_SOURCES = include/restclient-cpp/version.h
 
-test_program_SOURCES = vendor/jsoncpp-0.10.5/dist/jsoncpp.cpp test/tests.cpp test/test_restclient.cc test/test_connection.cc
+test_program_SOURCES = vendor/jsoncpp-0.10.5/dist/jsoncpp.cpp test/tests.cpp test/test_helpers.cc test/test_restclient.cc test/test_connection.cc
 test_program_LDADD = .libs/librestclient-cpp.a
 test_program_LDFLAGS=-Lvendor/gtest-1.7.0/lib/.libs -lgtest
 test_program_CPPFLAGS=-Iinclude -Ivendor/gtest-1.7.0/include -Ivendor/jsoncpp-0.10.5/dist

--- a/include/restclient-cpp/helpers.h
+++ b/include/restclient-cpp/helpers.h
@@ -53,14 +53,14 @@ namespace Helpers {
   // trim from start
   static inline std::string &ltrim(std::string &s) {  // NOLINT
     s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-          std::not1(std::ptr_fun<int, int>(std::isspace))));
+            [](int c) {return !std::isspace(c);}));
     return s;
   }
 
   // trim from end
   static inline std::string &rtrim(std::string &s) { // NOLINT
     s.erase(std::find_if(s.rbegin(), s.rend(),
-          std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+            [](int c) {return !std::isspace(c);}).base(), s.end());
     return s;
   }
 

--- a/test/test_helpers.cc
+++ b/test/test_helpers.cc
@@ -1,0 +1,62 @@
+#include "restclient-cpp/helpers.h"
+#include <gtest/gtest.h>
+#include <string>
+
+class HelpersTest : public ::testing::Test
+{
+ protected:
+
+    HelpersTest()
+    {
+    }
+
+    virtual ~HelpersTest()
+    {
+    }
+
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+};
+
+TEST_F(HelpersTest, TrimLeft) {
+  auto can_trim_left = std::string("    a set of characters");
+  auto cant_trim_left = std::string("a set of characters");
+  auto right_trim_ignored = std::string("a set of characters    ");
+
+  EXPECT_EQ(RestClient::Helpers::ltrim(can_trim_left),
+            std::string("a set of characters"));
+  EXPECT_EQ(RestClient::Helpers::ltrim(cant_trim_left),
+            std::string("a set of characters"));
+  EXPECT_EQ(RestClient::Helpers::ltrim(right_trim_ignored),
+            std::string("a set of characters    "));
+}
+
+TEST_F(HelpersTest, TrimRight) {
+  auto left_trim_ignored = std::string("    a set of characters");
+  auto cant_trim_right = std::string("a set of characters");
+  auto can_trim_right = std::string("a set of characters    ");
+
+  EXPECT_EQ(RestClient::Helpers::rtrim(left_trim_ignored),
+            std::string("    a set of characters"));
+  EXPECT_EQ(RestClient::Helpers::rtrim(cant_trim_right),
+            std::string("a set of characters"));
+  EXPECT_EQ(RestClient::Helpers::rtrim(can_trim_right),
+            std::string("a set of characters"));
+}
+
+TEST_F(HelpersTest, TrimBoth) {
+  auto can_trim_both = std::string("    a set of characters    ");
+  auto can_trim_left = std::string("    a set of characters");
+  auto can_trim_right = std::string("a set of characters    ");
+  auto cant_trim = std::string("a set of characters");
+
+  EXPECT_EQ(RestClient::Helpers::trim(can_trim_both), "a set of characters");
+  EXPECT_EQ(RestClient::Helpers::trim(can_trim_left), "a set of characters");
+  EXPECT_EQ(RestClient::Helpers::trim(can_trim_right), "a set of characters");
+  EXPECT_EQ(RestClient::Helpers::trim(cant_trim), "a set of characters");
+}


### PR DESCRIPTION
ptr_fun was deprecated in C++11, and removed in C++17. lambdas
have also been around since C++11. so there should be no loss in
supported targets, but also adds in support for C++17 and beyond.