### PR TITLE
Set minimum CMake version to 3.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(restclient-cpp
   VERSION 0.5.1


### PR DESCRIPTION
HOMEPAGE_URL in project() needs 3.12.

[3.11](https://cmake.org/cmake/help/v3.11/command/project.html) vs.  [3.12](https://cmake.org/cmake/help/v3.12/command/project.html)

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
