### PR TITLE
Replace hardcoded installation directories with GNUInstallDirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,12 @@ target_link_libraries(restclient-cpp
   PUBLIC Threads::Threads
 )
 
-set(INCLUDE_INSTALL_DIR "include/restclient-cpp" )
-set(CONFIG_INSTALL_DIR "lib/cmake/restclient-cpp" )
-set(RUNTIME_INSTALL_DIR "bin" )
-set(LIB_INSTALL_DIR "lib" )
-set(DATA_INSTALL_DIR "share/restclient-cpp" )
+include(GNUInstallDirs)
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/restclient-cpp" )
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/restclient-cpp" )
+set(RUNTIME_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" )
+set(LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" )
+set(DATA_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/restclient-cpp" )
 
 install(TARGETS restclient-cpp EXPORT restclient-cppTargets
   PUBLIC_HEADER DESTINATION ${INCLUDE_INSTALL_DIR}


### PR DESCRIPTION
GNUInstallDirs are portable, many users are familiar with them and they make the
life of package maintainers easier.


----

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change

## CMake compatibilty

GNUInstallDirs is available in 3.10:
<https://cmake.org/cmake/help/v3.10/module/GNUInstallDirs.html>.

## Reasoning

Linux distributions usually have profiles for CMake that set these directories
to the right locations. This change will make packaging easier.

## Other

I have left the old variables intact for backwards compatibility.