### PR TITLE
Add CURL and Threads as dependency in CMake config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,11 @@ install(TARGETS restclient-cpp EXPORT restclient-cppTargets
 
 include(CMakePackageConfigHelpers)
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake.in"
-  "@PACKAGE_INIT@\ninclude(\${CMAKE_CURRENT_LIST_DIR}/\@PROJECT_NAME\@Targets.cmake)\n")
+  "@PACKAGE_INIT@\n"
+  "include(CMakeFindDependencyMacro)\n"
+  "find_dependency(CURL REQUIRED)\n"
+  "find_dependency(Threads REQUIRED)\n"
+  "include(\${CMAKE_CURRENT_LIST_DIR}/\@PROJECT_NAME\@Targets.cmake)\n")
 configure_package_config_file(
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake


### PR DESCRIPTION
Use find_dependency() to depend on CURL and Threads so CMake users don't have to
do it themselves.


----

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change

## CMake compatibilty

* `CMakeFindDependencyMacro` and `find_dependency()` are available in 3.10:
  <https://cmake.org/cmake/help/v3.10/module/CMakeFindDependencyMacro.html>.
* `FindCurl` is available in 3.10:
  <https://cmake.org/cmake/help/v3.10/module/FindCURL.html>.
* `FindThreads` is available in 3.10:
  <https://cmake.org/cmake/help/v3.10/module/FindThreads.html>.

## Reasoning

Since curl and threads are not optional, they should be required by
`restclient-cppConfig.cmake`, in my opinion. It makes the CMakeLists.txt of
users a bit cleaner and shorter and has no downsides, as far as I'm aware.

### Before:

``` cmake
find_package(CURL REQUIRED)
find_package(Threads REQUIRED)
find_package(restclient-cpp 0.5 REQUIRED CONFIG)
```

### After:

``` cmake
find_package(restclient-cpp 0.5 REQUIRED CONFIG)
```