### PR TITLE
Use the standard CMake-flag BUILD_SHARED_LIBS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,12 @@ find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
 find_package(jsoncpp)
 
-if(NOT DEFINED COMPILE_TYPE)
-  set(COMPILE_TYPE SHARED)
-endif(NOT DEFINED COMPILE_TYPE)
+option(BUILD_SHARED_LIBS "Build shared library." YES)
+if(COMPILE_TYPE STREQUAL "SHARED")
+  set(BUILD_SHARED_LIBS YES)
+endif()
 
-add_library(restclient-cpp ${COMPILE_TYPE}
+add_library(restclient-cpp
   source/restclient.cc
   source/connection.cc
   source/helpers.cc


### PR DESCRIPTION
`COMPILE_TYPE` is left in for backwards compatibility.

----

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change

## CMake compatibilty

`BUILD_SHARED_LIBS` is availbale in CMake 3.10:
<https://cmake.org/cmake/help/v3.10/variable/BUILD_SHARED_LIBS.html>

## Reasoning

Will make life easier for package maintainers and CMake users who already know
about that flag immediately recognize it's function.
