### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,19 @@ Otherwise you can do the regular autotools dance:
 make install
 ```
 
+Alternatively, you can build and install restclient-cpp using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install restclient-cpp
+```
+
+The restclient-cpp port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Contribute
 All contributions are highly appreciated. This includes filing issues,
 updating documentation and writing code. Please take a look at the


### PR DESCRIPTION
restclient-cpp is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build restclient-cpp, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for restclient-cpp and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.