### PR TITLE
These two lines allow the scope of the property <target> for the public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,11 @@ list(APPEND restclient-cpp_PUBLIC_HEADERS
 # target_sources(restclient-cpp PRIVATE ${restclient-cpp_PUBLIC_HEADERS})
 set_property(TARGET restclient-cpp PROPERTY
   PUBLIC_HEADER ${restclient-cpp_PUBLIC_HEADERS})
-target_include_directories(restclient-cpp PRIVATE include)
+target_include_directories(restclient-cpp
+    PRIVATE include    
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+)
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/version.h.in")
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/version.h.in" [=[


### PR DESCRIPTION
Headers to be available when making use of the `add_subdirectory` from a
parent project.

This will allow other `add_subdirectory`'s to reference the headers during
the build process of cmake within `target_include_directories`.

This would make issues like #130 easier to do for cmake users.
This change also moves the file towards CMake standards.

I can give a more detailed explanation if needed. I can do more cleanup if needed as well.
I noticed there aren't tests for installation of files, not sure if that is something interested in or expected. Can do if needed for idempotent issues for changes like this.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [x] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
