### PR TITLE
write callback and termination API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,27 +16,35 @@ librestclient_cpp_la_LDFLAGS=-version-info 2:1:1
 
 dist_doc_DATA = README.md
 
-.PHONY: test check clean-coverage-files coverage-html include/restclient-cpp/version.h lint ci docker-services
+.PHONY: test check clean-coverage-files coverage-html include/restclient-cpp/version.h lint ci docker-services clean-docker-services
 
 include/restclient-cpp/version.h:
 	m4 -I ${top_srcdir}/m4 -DM4_RESTCLIENT_VERSION=$(PACKAGE_VERSION) version.h.m4 > ${top_srcdir}/$@ 
  
 
 
-test: check
+test: check docker-services
 	./test-program
 
 valgrind: check
 	valgrind --leak-check=full --error-exitcode=1 ./test-program
 
 lint:
-	cpplint --filter=-legal/copyright include/restclient-cpp/*.h source/*.cc
+	cpplint --filter=-legal/copyright --root=$(CURDIR) include/restclient-cpp/*.h source/*.cc
 
 docker-services:
-	docker inspect --format="{{ .State.Running }}" restclient-proxy &> /dev/null || docker run -d --name restclient-proxy -p 3128:3128 chrisdaish/squid
-	docker ps -a
+	[ -n "$$(docker ps --quiet --filter name=restclient-cpp-httpbin)" ] || \
+		docker run --detach -p 8998:80 --name restclient-cpp-httpbin kennethreitz/httpbin
+	[ -n "$$(docker ps --quiet --filter name=restclient-cpp-squid)" ] || \
+		docker run --detach -p 3128:3128 --name restclient-cpp-squid \
+		--volume "$(CURDIR)/test/squid.conf:/etc/squid/squid.conf:ro" sameersbn/squid:3.5.27-2
+	docker ps --all --filter 'name=^restclient-cpp-'
 
-ci: lint docker-services test valgrind
+clean-docker-services:
+	docker rm --force restclient-cpp-httpbin 2>/dev/null || true
+	docker rm --force restclient-cpp-squid 2>/dev/null || true
+
+ci: lint test valgrind
 
 clean-local:
 	find . -name "*.gcda" -print0 | xargs -0 rm

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -23,6 +23,12 @@
 namespace RestClient {
 
 /**
+ * @brief define type used for RestClient write callback
+ */
+typedef size_t (*WriteCallback)(void *data, size_t size,
+                  size_t nmemb, void *userdata);
+
+/**
   * @brief Connection object for advanced usage
   */
 class Connection {
@@ -146,6 +152,9 @@ class Connection {
     explicit Connection(const std::string& baseUrl);
     ~Connection();
 
+    // Terminate open connection
+    void Terminate();
+
     // Instance configuration methods
     // configure basic auth
     void SetBasicAuth(const std::string& username,
@@ -193,6 +202,9 @@ class Connection {
     // set CURLOPT_UNIX_SOCKET_PATH
     void SetUnixSocketPath(const std::string& unixSocketPath);
 
+    // set CURLOPT_WRITEFUNCTION
+    void SetWriteFunction(WriteCallback write_callback);
+
     std::string GetUserAgent();
 
     RestClient::Connection::Info GetInfo();
@@ -220,7 +232,12 @@ class Connection {
     RestClient::Response head(const std::string& uri);
     RestClient::Response options(const std::string& uri);
 
+    // GET with custom response structure
+    RestClient::Response*
+    get(const std::string& uri, RestClient::Response* response);
+
  private:
+    CURL* getCurlHandle();
     CURL* curlHandle;
     std::string baseUrl;
     RestClient::HeaderFields headerFields;
@@ -244,6 +261,9 @@ class Connection {
     std::string uriProxy;
     std::string unixSocketPath;
     char curlErrorBuf[CURL_ERROR_SIZE];
+    RestClient::WriteCallback writeCallback;
+    RestClient::Response*
+    performCurlRequest(const std::string& uri, RestClient::Response* resp);
     RestClient::Response performCurlRequest(const std::string& uri);
 };
 };  // namespace RestClient

--- a/test/squid.conf
+++ b/test/squid.conf
@@ -1,0 +1,9 @@
+acl CONNECT method CONNECT
+http_access allow localhost manager
+http_access deny manager
+acl all src 0.0.0.0/0
+http_access allow all
+http_access deny all
+http_port 3128
+coredump_dir /var/spool/squid
+url_rewrite_children 1 startup=1 idle=1 concurrency=0

--- a/test/test_restclient.cc
+++ b/test/test_restclient.cc
@@ -3,6 +3,8 @@
 #include <json/json.h>
 #include <string>
 
+#include "tests.h"
+
 class RestClientTest : public ::testing::Test
 {
  protected:
@@ -24,32 +26,31 @@ class RestClientTest : public ::testing::Test
     {
       RestClient::disable();
     }
-
 };
 
 // DELETE Tests
 // check return code
 TEST_F(RestClientTest, TestRestClientDELETECode)
 {
-  RestClient::Response res = RestClient::del("http://httpbin.org/delete");
+  RestClient::Response res = RestClient::del(RestClient::TestUrl+"/delete");
   EXPECT_EQ(200, res.code);
 }
 
 TEST_F(RestClientTest, TestRestClientDELETEBody)
 {
-  RestClient::Response res = RestClient::del("https://httpbin.org/delete");
+  RestClient::Response res = RestClient::del(RestClient::TestUrl+"/delete");
   Json::Value root;
   std::istringstream str(res.body);
   str >> root;
 
-  EXPECT_EQ("https://httpbin.org/delete", root.get("url", "no url set").asString());
+  EXPECT_EQ(RestClient::TestUrl+"/delete", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
 
 // check for failure
 TEST_F(RestClientTest, TestRestClientDELETEFailureCode)
 {
-  std::string u = "http://nonexistent";
+  std::string u = RestClient::TestNonExistantUrl;
   RestClient::Response res = RestClient::del(u);
   // 6 = CURLE_COULDNT_RESOLVE_HOST 
   EXPECT_EQ(6, res.code);
@@ -57,14 +58,14 @@ TEST_F(RestClientTest, TestRestClientDELETEFailureCode)
 
 TEST_F(RestClientTest, TestRestClientDELETEHeaders)
 {
-  RestClient::Response res = RestClient::del("https://httpbin.org/delete");
+  RestClient::Response res = RestClient::del(RestClient::TestUrl+"/delete");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
 
 // GET Tests
 TEST_F(RestClientTest, TestRestClientGETCode)
 {
-  RestClient::Response res = RestClient::get("https://httpbin.org/get");
+  RestClient::Response res = RestClient::get(RestClient::TestUrl+"/get");
   EXPECT_EQ(200, res.code);
 }
 
@@ -76,19 +77,19 @@ TEST_F(RestClientTest, TestRestClientGETHTTP2Code)
 
 TEST_F(RestClientTest, TestRestClientGETBodyCode)
 {
-  RestClient::Response res = RestClient::get("https://httpbin.org/get");
+  RestClient::Response res = RestClient::get(RestClient::TestUrl+"/get");
   Json::Value root;
   std::istringstream str(res.body);
   str >> root;
 
-  EXPECT_EQ("https://httpbin.org/get", root.get("url", "no url set").asString());
+  EXPECT_EQ(RestClient::TestUrl+"/get", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
 
 // check for failure
 TEST_F(RestClientTest, TestRestClientGETFailureCode)
 {
-  std::string u = "http://nonexistent";
+  std::string u = RestClient::TestNonExistantUrl;
   RestClient::Response res = RestClient::get(u);
   EXPECT_EQ("Couldn't resolve host name", res.body);
   // 6 = CURLE_COULDNT_RESOLVE_HOST 
@@ -97,7 +98,7 @@ TEST_F(RestClientTest, TestRestClientGETFailureCode)
 
 TEST_F(RestClientTest, TestRestClientGETHeaders)
 {
-  RestClient::Response res = RestClient::get("https://httpbin.org/get");
+  RestClient::Response res = RestClient::get(RestClient::TestUrl+"/get");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
 
@@ -105,25 +106,25 @@ TEST_F(RestClientTest, TestRestClientGETHeaders)
 // check return code
 TEST_F(RestClientTest, TestRestClientPOSTCode)
 {
-  RestClient::Response res = RestClient::post("https://httpbin.org/post", "text/text", "data");
+  RestClient::Response res = RestClient::post(RestClient::TestUrl+"/post", "text/text", "data");
   EXPECT_EQ(200, res.code);
 }
 
 TEST_F(RestClientTest, TestRestClientPOSTBody)
 {
-  RestClient::Response res = RestClient::post("https://httpbin.org/post", "text/text", "data");
+  RestClient::Response res = RestClient::post(RestClient::TestUrl+"/post", "text/text", "data");
   Json::Value root;
   std::istringstream str(res.body);
   str >> root;
 
-  EXPECT_EQ("https://httpbin.org/post", root.get("url", "no url set").asString());
+  EXPECT_EQ(RestClient::TestUrl+"/post", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
 
 // check for failure
 TEST_F(RestClientTest, TestRestClientPOSTFailureCode)
 {
-  std::string u = "http://nonexistent";
+  std::string u = RestClient::TestNonExistantUrl;
   RestClient::Response res = RestClient::post(u, "text/text", "data");
   // 6 = CURLE_COULDNT_RESOLVE_HOST 
   EXPECT_EQ(6, res.code);
@@ -131,7 +132,7 @@ TEST_F(RestClientTest, TestRestClientPOSTFailureCode)
 
 TEST_F(RestClientTest, TestRestClientPOSTHeaders)
 {
-  RestClient::Response res = RestClient::post("https://httpbin.org/post", "text/text", "data");
+  RestClient::Response res = RestClient::post(RestClient::TestUrl+"/post", "text/text", "data");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
 
@@ -139,25 +140,25 @@ TEST_F(RestClientTest, TestRestClientPOSTHeaders)
 // check return code
 TEST_F(RestClientTest, TestRestClientPUTCode)
 {
-  RestClient::Response res = RestClient::put("https://httpbin.org/put", "text/text", "data");
+  RestClient::Response res = RestClient::put(RestClient::TestUrl+"/put", "text/text", "data");
   EXPECT_EQ(200, res.code);
 }
 
 TEST_F(RestClientTest, TestRestClientPUTBody)
 {
-  RestClient::Response res = RestClient::put("https://httpbin.org/put", "text/text", "data");
+  RestClient::Response res = RestClient::put(RestClient::TestUrl+"/put", "text/text", "data");
   Json::Value root;
   std::istringstream str(res.body);
   str >> root;
 
-  EXPECT_EQ("https://httpbin.org/put", root.get("url", "no url set").asString());
+  EXPECT_EQ(RestClient::TestUrl+"/put", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
 
 // check for failure
 TEST_F(RestClientTest, TestRestClientPUTFailureCode)
 {
-  std::string u = "http://nonexistent";
+  std::string u = RestClient::TestNonExistantUrl;
   RestClient::Response res = RestClient::put(u, "text/text", "data");
   // 6 = CURLE_COULDNT_RESOLVE_HOST 
   EXPECT_EQ(6, res.code);
@@ -165,7 +166,7 @@ TEST_F(RestClientTest, TestRestClientPUTFailureCode)
 
 TEST_F(RestClientTest, TestRestClientPUTHeaders)
 {
-  RestClient::Response res = RestClient::put("https://httpbin.org/put", "text/text", "data");
+  RestClient::Response res = RestClient::put(RestClient::TestUrl+"/put", "text/text", "data");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
 
@@ -173,25 +174,25 @@ TEST_F(RestClientTest, TestRestClientPUTHeaders)
 // check return code
 TEST_F(RestClientTest, TestRestClientPATCHCode)
 {
-  RestClient::Response res = RestClient::patch("https://httpbin.org/patch", "text/text", "data");
+  RestClient::Response res = RestClient::patch(RestClient::TestUrl+"/patch", "text/text", "data");
   EXPECT_EQ(200, res.code);
 }
 
 TEST_F(RestClientTest, TestRestClientPATCHBody)
 {
-  RestClient::Response res = RestClient::patch("https://httpbin.org/patch", "text/text", "data");
+  RestClient::Response res = RestClient::patch(RestClient::TestUrl+"/patch", "text/text", "data");
   Json::Value root;
   std::istringstream str(res.body);
   str >> root;
 
-  EXPECT_EQ("https://httpbin.org/patch", root.get("url", "no url set").asString());
+  EXPECT_EQ(RestClient::TestUrl+"/patch", root.get("url", "no url set").asString());
   EXPECT_EQ("restclient-cpp/" RESTCLIENT_VERSION, root["headers"].get("User-Agent", "no url set").asString());
 }
 
 // check for failure
 TEST_F(RestClientTest, TestRestClientPATCHFailureCode)
 {
-  std::string u = "http://nonexistent";
+  std::string u = RestClient::TestNonExistantUrl;
   RestClient::Response res = RestClient::patch(u, "text/text", "data");
   // 6 = CURLE_COULDNT_RESOLVE_HOST 
   EXPECT_EQ(6, res.code);
@@ -199,23 +200,23 @@ TEST_F(RestClientTest, TestRestClientPATCHFailureCode)
 
 TEST_F(RestClientTest, TestRestClientPATCHHeaders)
 {
-  RestClient::Response res = RestClient::patch("https://httpbin.org/put", "text/text", "data");
+  RestClient::Response res = RestClient::patch(RestClient::TestUrl+"/put", "text/text", "data");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
 
 // OPTIONS Tests
 // check return code
 // Disabled as httpbin does not support options requests for now
-TEST_F(RestClientTest, DISABLED_TestRestClientOPTIONSCode)
+TEST_F(RestClientTest, TestRestClientOPTIONSCode)
 {
-  RestClient::Response res = RestClient::options("https://httpbin.org/options");
+  RestClient::Response res = RestClient::options("https://api.reqbin.com/api/v1/requests");
   EXPECT_EQ(200, res.code);
 }
 
 // check for failure
 TEST_F(RestClientTest, TestRestClientOPTIONSFailureCode)
 {
-  std::string u = "http://nonexistent";
+  std::string u = RestClient::TestNonExistantUrl;
   RestClient::Response res = RestClient::options(u);
   // 6 = CURLE_COULDNT_RESOLVE_HOST 
   EXPECT_EQ(6, res.code);
@@ -223,13 +224,14 @@ TEST_F(RestClientTest, TestRestClientOPTIONSFailureCode)
 
 TEST_F(RestClientTest, TestRestClientOPTIONSHeaders)
 {
-  RestClient::Response res = RestClient::options("https://httpbin.org/options");
+  RestClient::Response res = RestClient::options(
+      RestClient::TestUrl+"/options");
   EXPECT_EQ("keep-alive", res.headers["Connection"]);
 }
 
 TEST_F(RestClientTest, TestRestClientAuth)
 {
-  RestClient::Response res = RestClient::get("https://foo:bar@httpbin.org/basic-auth/foo/bar");
+  RestClient::Response res = RestClient::get("http://foo:bar@" + RestClient::TestServer + "/basic-auth/foo/bar");
   EXPECT_EQ(200, res.code);
 
   Json::Value root;
@@ -239,13 +241,13 @@ TEST_F(RestClientTest, TestRestClientAuth)
   EXPECT_EQ("foo", root.get("user", "no user").asString());
   EXPECT_EQ(true, root.get("authenticated", false).asBool());
 
-  res = RestClient::get("https://httpbin.org/basic-auth/foo/bar");
+  res = RestClient::get("http://" + RestClient::TestServer + "/basic-auth/foo/bar");
   EXPECT_EQ(401, res.code);
 }
 
 TEST_F(RestClientTest, TestRestClientHeadCode)
 {
-  RestClient::Response res = RestClient::head("https://httpbin.org/get");
+  RestClient::Response res = RestClient::head(RestClient::TestUrl+"/get");
   EXPECT_EQ(200, res.code);
   EXPECT_EQ("", res.body);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1,8 +1,26 @@
 #include <iostream>
 #include <gtest/gtest.h>
 
+#include "tests.h"
+
+// Define shared constants
+namespace RestClient
+{
+    std::string TestNonExistantUrl;
+    std::string TestServer;
+    std::string TestUrl;
+    std::string TestProxyUrl;
+};
+
 int main(int argc, char **argv)
 {
+    // Initialize shared constants
+    // Ports below should match what is set in Makefile.in
+    RestClient::TestNonExistantUrl = "http://nonexistent";
+    RestClient::TestServer = "127.0.0.1:8998";
+    RestClient::TestUrl = "http://" + RestClient::TestServer;
+    RestClient::TestProxyUrl = "http://127.0.0.1:3128";
+
 	::testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();
 }

--- a/test/tests.h
+++ b/test/tests.h
@@ -1,0 +1,14 @@
+#ifndef TEST_TESTS_H_
+#define TEST_TESTS_H_
+
+#include <string>
+
+namespace RestClient 
+{
+    extern std::string TestNonExistantUrl;
+    extern std::string TestServer;
+    extern std::string TestUrl;
+    extern std::string TestProxyUrl;
+};
+
+#endif // TEST_TESTS_H_


### PR DESCRIPTION
# Description

1. Allow write callback.  Application was to use it to leverage the Kubernetes watch API which maintains a long-running connection.
1. API to terminate connection from another thread.
1. Fix all the disabled/broken CI tests that block the merge.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [X] CI passes
- [X] Description of proposed change
- [X] Documentation (README, code doc blocks, etc) is updated
- [X] Existing issue is referenced if there is one
    - #162 write callback support
    - #161 CI does not work locally
- [X] Unit tests for the proposed change
