### PR TITLE
Small pkg-config related changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ lib_LTLIBRARIES=librestclient-cpp.la
 librestclient_cpp_la_SOURCES=source/restclient.cc source/connection.cc source/helpers.cc
 librestclient_cpp_la_CXXFLAGS=-fPIC -std=c++11
 librestclient_cpp_la_LDFLAGS=-version-info 2:1:1
+pkgconfig_DATA=restclient-cpp.pc
 
 dist_doc_DATA = README.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,9 @@ AC_CHECK_LIB([curl], [main])
 AC_C_INLINE
 AC_TYPE_SIZE_T
 
+dnl Set install dir for pkg-config file
+PKG_INSTALLDIR
+
 AC_CONFIG_FILES([Makefile restclient-cpp.pc])
 
 # enable code coverage with ./configure --enable-coverage

--- a/restclient-cpp.pc.in
+++ b/restclient-cpp.pc.in
@@ -7,6 +7,6 @@ Name: restclient-cpp
 Description: C++ client for making HTTP/REST requests
 URL: http://code.mrtazz.com/restclient-cpp/
 Version: @VERSION@
-Requires: curl
+Requires: libcurl
 Libs: -L${libdir} -lrestclient-cpp
 Cflags: -I${includedir}


### PR DESCRIPTION
The changes to the `configure.ac` and `Makefile.am` make it so that the
autotools install the library's pkg-config file alongside the rest of
the library.

The change in the `restclient-cpp.pc.in` file changes the requires to
use the actual name of cURL's pkg-config file (libcurl).

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [X] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
