### PR TITLE
Provide the possibility to include headers using target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_include_directories(restclient-cpp
     PRIVATE include    
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    PUBLIC $<INSTALL_INTERFACE:include>
 )
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/version.h.in")


### PR DESCRIPTION
## Description
In order to use  the target_link_directories on an external project,  an extra statement  had to be added to the target_include_directories, as shown on the diff. If that is not done, the restclient_cppTarges.cmake file will not  contain the `INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"` statement, under set_target_properties. As a consequence, it won't be possible to include the headers on my project using:

`
target_include_directories(${LibName}
    PRIVATE restclient-cpp) 
`

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
