### PR TITLE
seeds SetSSLContextCallback

### DIFF
--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -29,6 +29,11 @@ typedef size_t (*WriteCallback)(void *data, size_t size,
                   size_t nmemb, void *userdata);
 
 /**
+ * @brief define type used for RestClient SSL context callback
+ */
+typedef CURLcode (*SSLCtxCallback)(CURL *curl, void *ssl_ctx, void *userptr);
+
+/**
   * @brief Connection object for advanced usage
   */
 class Connection {
@@ -266,6 +271,7 @@ class Connection {
     std::string unixSocketPath;
     char curlErrorBuf[CURL_ERROR_SIZE];
     RestClient::WriteCallback writeCallback;
+    RestClient::SSLCtxCallback sslContextCallback;
     RestClient::Response*
     performCurlRequest(const std::string& uri, RestClient::Response* resp);
     RestClient::Response performCurlRequest(const std::string& uri);

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -39,6 +39,13 @@ RestClient::Connection::Connection(const std::string& baseUrl)
   this->progressFn = NULL;
   this->progressFnData = NULL;
   this->writeCallback = RestClient::Helpers::write_callback;
+  
+  #if __cplusplus >= 201103L
+    this->sslContextCallback = nullptr;
+  #else
+    this->sslContextCallback = NULL;
+  #endif
+
   this->verifyPeer = true;
 }
 
@@ -349,6 +356,20 @@ writeCallback) {
 }
 
 /**
+ * @brief Sets a callback to enable custom setting of the ssl context,
+ * at construction time. For details,
+ * see https://curl.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html
+ *
+ * @param callback - A user callback allowing for customization of the ssl
+ context at construction time.
+ *
+ */
+void RestClient::Connection::SetSSLContextCallback(
+    RestClient::SSLCtxCallback callback) {
+  this->sslContextCallback = callback;
+}
+
+/**
  * @brief helper function to get called from the actual request methods to
  * prepare the curlHandle for transfer with generic options, perform the
  * request and record some stats from the last request and then reset the
@@ -401,6 +422,17 @@ RestClient::Connection::performCurlRequest(const std::string& uri,
                    this->writeCallback);
   /** set data object to pass to callback function */
   curl_easy_setopt(getCurlHandle(), CURLOPT_WRITEDATA, ret);
+  /** set ssl context callback function */
+  #if __cplusplus >= 201103L 
+    if (this->sslContextCallback != nullptr) {
+      curl_easy_setopt(getCurlHandle(), CURLOPT_SSL_CTX_FUNCTION,
+      this->sslContextCallback);
+    }
+  #else
+    if (this->sslContextCallback != NULL) {
+      curl_easy_setopt(getCurlHandle(), CURLOPT_SSL_CTX_FUNCTION, this->sslContextCallback);
+    }
+  #endif
   /** set the header callback function */
   curl_easy_setopt(getCurlHandle(), CURLOPT_HEADERFUNCTION,
                    Helpers::header_callback);

--- a/test/test_connection.cc
+++ b/test/test_connection.cc
@@ -65,6 +65,20 @@ TEST_F(ConnectionTestRemote, TestFailForInvalidCA)
   EXPECT_EQ(77, res.code);
 }
 
+static CURLcode sslctx_fail_function(CURL *curl, void *ctx, void *parm)
+{
+  return CURLE_SSL_CONNECT_ERROR;
+}
+
+TEST_F(ConnectionTestRemote, TestAllowSettingSSLContext)
+{
+  // setting a callback which returns error. The call should fail.
+  conn->SetSSLContextCallback(*sslctx_fail_function);
+  RestClient::Response res = conn->get("/get");
+
+  EXPECT_EQ(CURLE_SSL_CONNECT_ERROR, res.code);
+}
+
 TEST_F(ConnectionTestRemote, TestAllowInsecure)
 {
   // set a non-existing file for the CA file, should allow access anyway


### PR DESCRIPTION
There should be a way to set SSL context callback. 

Sample code:
```c++
static CURLcode sslctx_fail_function(CURL *curl, void *ctx, void *parm)
{
  return CURLE_OK;
}

void foo()
{
  ...

  conn->SetVerifyPeer(true);
  conn->SetSSLContextCallback(*sslctx_fn);
  RestClient::Response res = conn->get("/get");
  EXPECT_EQ(200, res.code);
}
```

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [X] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
