### PR TITLE
Support NTLM authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ RestClient::Connection* conn = new RestClient::Connection("http://url.com");
 // configure basic auth
 conn->SetBasicAuth("WarMachine68", "WARMACHINEROX");
 
+// to authenticate using the NTLM protocol
+conn->SetAuthProtocol( CURLAUTH_NTLM );
+
 // set connection timeout to 5s
 conn->SetTimeout(5);
 

--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -160,6 +160,9 @@ class Connection {
     void SetBasicAuth(const std::string& username,
                       const std::string& password);
 
+    // Allow other authentication protocols to be used (such as NTLM)
+    void SetAuthProtocol( unsigned int proto ) { authProtocol = proto; }
+    
     // set connection timeout to seconds
     void SetTimeout(int seconds);
 
@@ -254,6 +257,7 @@ class Connection {
       std::string username;
       std::string password;
     } basicAuth;
+    unsigned long authProtocol = 0;
     std::string customUserAgent;
     std::string caInfoFilePath;
     RequestInfo lastRequest;

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -421,7 +421,8 @@ RestClient::Connection::performCurlRequest(const std::string& uri,
   if (this->basicAuth.username.length() > 0) {
     std::string authString = std::string(this->basicAuth.username + ":" +
                                          this->basicAuth.password);
-    curl_easy_setopt(getCurlHandle(), CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_easy_setopt(getCurlHandle(), CURLOPT_HTTPAUTH,
+              this->authProtocol == 0 ? CURLAUTH_BASIC : this->authProtocol);
     curl_easy_setopt(getCurlHandle(), CURLOPT_USERPWD, authString.c_str());
   }
   /** set error buffer */


### PR DESCRIPTION
To authenticate to Microsoft Dynamics CRM on premises, we are using the CURL command line with the --ntlm option to successfully authenticate using basic authentication.
Although the NTLM protocol is supported by libcurl, a change was needed to access this functionality from restclient-cpp.
I added a SetAuthProtocol method to RestClient::Connection which accepts all authentication protocols supported by libcurl (Basic, Digest, NTLM, etc.).
This change was reflected in the documentation as well.
Let me know what you think!
Cheers,
Filipe Custódio