### PR TITLE
Add Connection::SetVerifyHost(bool) method

### DIFF
--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -196,6 +196,9 @@ class Connection {
     // set CURLOPT_SSL_VERIFYPEER. Default is true.
     void SetVerifyPeer(bool verifyPeer);
 
+    // set CURLOPT_SSL_VERIFYHOST. Default is true.
+    void SetVerifyHost(bool verifyHost);
+
     // set CURLOPT_KEYPASSWD.
     void SetKeyPassword(const std::string& keyPassword);
 
@@ -262,6 +265,7 @@ class Connection {
     std::string keyPath;
     std::string keyPassword;
     bool verifyPeer;
+    bool verifyHost;
     std::string uriProxy;
     std::string unixSocketPath;
     char curlErrorBuf[CURL_ERROR_SIZE];

--- a/source/connection.cc
+++ b/source/connection.cc
@@ -40,6 +40,7 @@ RestClient::Connection::Connection(const std::string& baseUrl)
   this->progressFnData = NULL;
   this->writeCallback = RestClient::Helpers::write_callback;
   this->verifyPeer = true;
+  this->verifyHost = true;
 }
 
 /**
@@ -303,6 +304,17 @@ RestClient::Connection::SetVerifyPeer(bool verifyPeer) {
 }
 
 /**
+ * @brief set SSL host verification flag
+ *
+ * @param boolean (default is true)
+ *
+ */
+void
+RestClient::Connection::SetVerifyHost(bool verifyHost) {
+  this->verifyHost = verifyHost;
+}
+
+/**
  * @brief set HTTP proxy address and port
  *
  * @param proxy address with port number
@@ -499,6 +511,12 @@ RestClient::Connection::performCurlRequest(const std::string& uri,
   if (!this->verifyPeer) {
     curl_easy_setopt(getCurlHandle(), CURLOPT_SSL_VERIFYPEER,
                      this->verifyPeer);
+  }
+
+  // set host verification
+  if (!this->verifyHost) {
+    curl_easy_setopt(getCurlHandle(), CURLOPT_SSL_VERIFYHOST,
+                     this->verifyHost);
   }
 
   // set web proxy address


### PR DESCRIPTION
SetVerifyHost method allows the user to set CURLOPT_SSL_VERIFYHOST option flag.

Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, code doc blocks, etc) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
