### PR TITLE
init Connection::curlErrorBuf[] at compile

### DIFF
--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -264,7 +264,7 @@ class Connection {
     bool verifyPeer;
     std::string uriProxy;
     std::string unixSocketPath;
-    char curlErrorBuf[CURL_ERROR_SIZE];
+    char curlErrorBuf[CURL_ERROR_SIZE] = {0};
     RestClient::WriteCallback writeCallback;
     RestClient::Response*
     performCurlRequest(const std::string& uri, RestClient::Response* resp);


### PR DESCRIPTION
**DESCRIPTION**

The PR is intended to address the the issue as noted in https://github.com/mrtazz/restclient-cpp/issues/173 where Valgrind has raised a potential issue due to the fact that the `curlErrorBuf` has not be explicitly initialised.  

The change simply initialises this array at compile time.

**REFS**

- [Original Issue](https://github.com/mrtazz/restclient-cpp/issues/173)

**CHECKLIST**

- [X] Description of proposed change
- [X] Existing issue is referenced if there is one
- [X] Unit tests for the proposed change (covered by valgrind)