### PR TITLE
Fix missing cstdint include

### DIFF
--- a/include/restclient-cpp/connection.h
+++ b/include/restclient-cpp/connection.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <map>
 #include <cstdlib>
+#include <cstdint>
 
 #include "restclient-cpp/restclient.h"
 #include "restclient-cpp/version.h"


### PR DESCRIPTION
The previous code did not compile under GCC-13 because libstdcpp
headers have changed such that cstdint is not included implicitly.
Add cstdint include when `uint64_t` types are used.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
