### PR TITLE
Removed force shared library for cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,6 @@ find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
 find_package(jsoncpp)
 
-option(BUILD_SHARED_LIBS "Build shared library." YES)
-if(COMPILE_TYPE STREQUAL "SHARED")
-  set(BUILD_SHARED_LIBS YES)
-endif()
-
 add_library(restclient-cpp
   source/restclient.cc
   source/connection.cc


### PR DESCRIPTION
Removed the option that overrides the type of library to be built. Having this option seemed to prevent others from building as a static library. Also, there was a seemingly related check for COMPILE_TYPE, which removed. 