### PR TITLE
Issue: 157 , made HeaderField map case-insensitive

### DIFF
--- a/include/restclient-cpp/restclient.h
+++ b/include/restclient-cpp/restclient.h
@@ -23,7 +23,24 @@ namespace RestClient {
 /**
   * public data definitions
   */
-typedef std::map<std::string, std::string> HeaderFields;
+
+// comparator for case-insensitive comparison in HeaderFeild map
+struct ci_comp
+{
+  struct nocase_compare
+  {
+    bool operator() (const unsigned char& c1, const unsigned char& c2) const {
+        return tolower (c1) < tolower (c2); 
+    }
+  };
+  bool operator() (const std::string & s1, const std::string & s2) const {
+    return std::lexicographical_compare 
+      (s1.begin (), s1.end (),   
+      s2.begin (), s2.end (),   
+      nocase_compare ());  
+  }
+};
+typedef std::map<std::string, std::string, ci_comp> HeaderFields;
 
 /** @struct Response
   *  @brief This structure represents the HTTP response data

--- a/test/test_restclient.cc
+++ b/test/test_restclient.cc
@@ -253,3 +253,36 @@ TEST_F(RestClientTest, TestRestClientHeadCode)
   EXPECT_EQ(200, res.code);
   EXPECT_EQ("", res.body);
 }
+
+// check for header map case-insensitivity 
+TEST_F(RestClientTest, TestHeaderCaseInsensitivity)
+{
+    RestClient::Response res = RestClient::get("https://httpbin.org/get");
+    bool caseInsensitive = false;
+
+    try {
+        std::string& lowerDate = res.headers.at("date");
+        std::string& upperDate = res.headers.at("Date");
+        caseInsensitive = (lowerDate == upperDate);
+    } catch (std::out_of_range&) {
+        caseInsensitive = false;
+    }
+
+    EXPECT_TRUE(caseInsensitive) << "Headers should be case-insensitive but were not.";
+}
+
+TEST_F(RestClientTest, TestHeaderContentTypeCaseInsensitivity)
+{
+    RestClient::Response res = RestClient::get("https://httpbin.org/get");
+    bool caseInsensitive = false;
+
+    try {
+        std::string& lowerContentType = res.headers.at("content-type");
+        std::string& upperContentType = res.headers.at("Content-Type");
+        caseInsensitive = (lowerContentType == upperContentType);
+    } catch (std::out_of_range&) {
+        caseInsensitive = false;
+    }
+
+    EXPECT_TRUE(caseInsensitive) << "Content-Type header should be case-insensitive but was not.";
+}


### PR DESCRIPTION
## Issue: #157 

Made the HeaderField map case-insensitive using a custom comparator. And added test cases for it.

